### PR TITLE
Mapping builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: java
 
-addons:
-  apt:
-    packages:
-      - oracle-java8-set-default
-
-dist: trusty
-
 sudo: required
+
+jdk:
+  - oraclejdk8
 
 cache:
   directories:
@@ -33,7 +29,7 @@ branches:
 
 before_install:
   # CommandBox Keys
-  - sudo apt-key adv --keyserver keys.gnupg.net --recv 6DA70622
+  - curl -fsSl https://downloads.ortussolutions.com/debs/gpg | sudo apt-key add -
   - sudo echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a
     /etc/apt/sources.list.d/commandbox.list
 
@@ -69,7 +65,7 @@ after_failure:
   # Spit out our Commandbox log in case we need to debug
   - box server log name=$ENGINE
   - cat `box system-log`
-  
+
 before_deploy:
   - cd $TRAVIS_BUILD_DIR
   - mkdir -p s3deploy
@@ -80,7 +76,7 @@ deploy:
   #Module Deployment
   - provider: s3
     on:
-      branch: 
+      branch:
         - master
         - development
       condition: "$ENGINE = lucee@4.5"
@@ -95,7 +91,7 @@ deploy:
   #API Docs Deployment
   - provider: s3
     on:
-      branch: 
+      branch:
         - master
         - development
       condition: "$ENGINE = lucee@4.5"
@@ -107,7 +103,6 @@ deploy:
     local-dir: build/apidocs
     upload-dir: coldbox-modules/$MODULE_ID
     acl: public_read
-
 
 after_deploy:
   - cd $TRAVIS_BUILD_DIR/build && box forgebox publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - ENGINE=lucee@5
     - ENGINE=adobe@11
     - ENGINE=adobe@2016
+    - ENGINE=adobe@2018
 
 branches:
   only:

--- a/Query Ideas.md
+++ b/Query Ideas.md
@@ -1,0 +1,55 @@
+// Something that matches any of these?
+
+// -> function when( boolean condition, ifTrue, ifFalse )
+// -> function raw( string text )
+
+// -> matchAll
+
+// -> constantScore
+
+// BooleanQuery.cfc
+// -> must
+// -> filter
+// -> should
+// -> mustNot
+
+// FullTextQuery.cfc
+// -> match
+// -> matchPhrase
+// -> matchPhrasePrefix
+// -> multiMatch
+// -> common
+// -> queryString
+// -> simpleQueryString
+
+// TermQuery.cfc
+// -> term
+// -> terms
+// -> range
+// -> exists
+// -> prefix
+// -> wildcard
+// -> regexp
+// -> fuzzy
+// -> type
+// -> ids
+
+// RangeQuery.cfc
+// -> gte
+// -> gt
+// -> lte
+// -> lt
+
+// can we be opinionated and only offer either equal or non-equal varities?
+// query.range( "date", 10, 20 );
+// { "range" = { "date" = { "gte" = 10, "lte" = 20 } } }
+
+// query.range( "date", 10, 20, greaterThanEqual = false );
+// { "range" = { "date" = { "gt" = 10, "lte" = 20 } } }
+
+// query.range( "date" ).gte( 10 ).lte( 20 );
+
+// JoinQuery.cfc
+
+
+// GeoQuery.cfc

--- a/box.json
+++ b/box.json
@@ -5,20 +5,20 @@
     "private":false,
     "defaultPort":0,
     "dependencies":{
-        "coldbox":"^4.3.0",
+        "coldbox":"^5.0.0",
         "workbench":"git+https://github.com/Ortus-Solutions/unified-workbench.git",
         "cbjavaloader":"^1.3.3+25"
     },
     "devDependencies":{
-        "testbox":"2.3.0+00044",
+        "testbox":"^2.3.0",
         "Jest":"https://github.com/searchbox-io/Jest/archive/master.zip"
     },
     "installPaths":{
-        "testbox":"testbox",
-        "coldbox":"coldbox",
-        "workbench":"workbench",
-        "cbjavaloader":"modules/cbjavaloader",
-        "Jest":"build/Jest"
+        "testbox":"testbox/",
+        "coldbox":"coldbox/",
+        "workbench":"workbench/",
+        "cbjavaloader":"modules/cbjavaloader/",
+        "Jest":"build/Jest/"
     },
     "testbox":{
         "runner":"http://localhost:49616"

--- a/config/Coldbox.cfc
+++ b/config/Coldbox.cfc
@@ -3,6 +3,18 @@ component{
 	// Configure ColdBox Application
 	function configure(){
 
+        moduleSettings = {
+            "cbElasticsearch" = {
+                "hosts" = [
+                    {
+                        "serverProtocol" = getSystemSetting( "ELASTICSEARCH_PROTOCOL", "http" ),
+                        "serverName" = getSystemSetting( "ELASTICSEARCH_HOST", "127.0.0.1" ),
+                        "serverPort" = getSystemSetting( "ELASTICSEARCH_PORT", "9200" )
+                    }
+                ]
+            }
+        };
+
 		// coldbox directives
 		coldbox = {
 			//Application Setup
@@ -77,6 +89,6 @@ component{
 			}
 		];
 
-	}
+    }
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  elasticsearch:
+    image: elasticsearch
+    environment:
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+      http.host: "0.0.0.0"
+      transport.host: "127.0.0.1"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+  app:
+    image: ortussolutions/commandbox
+    depends_on:
+      - elasticsearch
+    environment:
+      CFENGINE: "adobe@11"
+      PORT: 8080
+      SSL_PORT: 8443
+      ELASTICSEARCH_HOST: elasticsearch
+    ports:
+      - "8080:8080"
+      - "8443:8443"
+      - "8188:8088"
+    volumes:
+      # Mount our application in delgated mode
+      - .:/app:delegated
+    expose:
+      - "8080"
+      - "8443"
+      - "8088"

--- a/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
@@ -21,6 +21,11 @@ component
         return this;
     }
 
+    function addParameter( name, value ) {
+        variables.parameters[ name ] = value;
+        return this;
+    }
+
     function fields( callback ) {
         var dsl = variables.builder.create( callback );
         variables.parameters[ "fields" ] = dsl.properties;

--- a/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
@@ -9,8 +9,9 @@
 */
 component accessors="true" {
 
+    property name="builder" inject="MappingBuilder@cbElasticSearch";
+
     property name="name";
-    property name="builder";
     property name="parameters";
     property name="type" default="object";
 

--- a/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
@@ -1,0 +1,70 @@
+/**
+*
+* Elasticsearch Abstract Mapping Object
+*
+* @package cbElasticsearch.models.mappings
+* @author Eric Peterson <eric@ortussolutions.com>
+* @license Apache v2.0 <http://www.apache.org/licenses/>
+*
+*/
+component
+	accessors="true"
+{
+
+    property name="name";
+    property name="type";
+    property name="parameters";
+
+    function init() {
+        variables.parameters = {};
+        return this;
+    }
+
+    function onMissingMethod( missingMethodName, missingMethodArguments ) {
+        variables.parameters[ snakeCase( missingMethodName ) ] = missingMethodArguments[ 1 ];
+        return this;
+    }
+
+    private function snakeCase( str ) {
+        return arrayToList( words( capitalize( str, true ) ).map( function( w ) {
+            return lCase( w );
+        } ), "_" );
+    }
+
+    private function capitalize( str, preserveCase = false ) {
+        var strArray = listToArray( preserveCase ? str : lcase( str ), "" );
+        strArray[ 1 ] = uCase( strArray[ 1 ] );
+        return arrayToList( strArray, "" );
+    }
+
+    private function words( str ) {
+        return listToArray(
+            addSpaceBetweenCapitalLetters(
+                REReplace( str , "[\_\-]", " ", "ALL" )
+            ),
+            " "
+        );
+    }
+
+    private function addSpaceBetweenCapitalLetters( str ) {
+        var pattern = createObject( "java", "java.util.regex.Pattern" );
+        var matches = pattern.compile( "[A-Z]" ).matcher( str );
+        var newString = "";
+        var start = 0;
+        while( matches.find() ) {
+            if ( start == 0 ) {
+                start = matches.start() + 1;
+                continue;
+            }
+            newString &= mid( str, start, matches.start() - start + 1 ) & " ";
+            start = matches.start() + 1;
+        }
+
+        if ( newString == "" ) {
+            return str;
+        }
+
+        return newString & mid( str, start, len( str ) );
+    }
+
+}

--- a/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
@@ -12,11 +12,18 @@ component
 {
 
     property name="name";
-    property name="type" default="object";
+    property name="builder";
     property name="parameters";
+    property name="type" default="object";
 
     function init() {
         variables.parameters = {};
+        return this;
+    }
+
+    function fields( callback ) {
+        var dsl = variables.builder.create( callback );
+        variables.parameters[ "fields" ] = dsl.properties;
         return this;
     }
 

--- a/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
@@ -1,15 +1,13 @@
 /**
 *
-* Elasticsearch Abstract Mapping Object
+* ElasticSearch Abstract Mapping Object
 *
 * @package cbElasticsearch.models.mappings
-* @author Eric Peterson <eric@ortussolutions.com>
+* @author  Eric Peterson <eric@ortussolutions.com>
 * @license Apache v2.0 <http://www.apache.org/licenses/>
 *
 */
-component
-	accessors="true"
-{
+component accessors="true" {
 
     property name="name";
     property name="builder";

--- a/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/AbstractMapping.cfc
@@ -12,7 +12,7 @@ component
 {
 
     property name="name";
-    property name="type";
+    property name="type" default="object";
     property name="parameters";
 
     function init() {

--- a/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
@@ -1,15 +1,15 @@
 /**
 *
-* Elasticsearch Mapping Blueprint Object
+* ElasticSearch Mapping Blueprint Object
 *
 * @package cbElasticsearch.models.mappings
-* @author Eric Peterson <eric@ortussolutions.com>
+* @author  Eric Peterson <eric@ortussolutions.com>
 * @license Apache v2.0 <http://www.apache.org/licenses/>
 *
 */
-component
-	accessors="true"
-{
+component accessors="true" {
+
+    property name="wirebox" inject="wirebox";
 
     property name="builder";
     property name="properties";
@@ -218,7 +218,7 @@ component
 
     private function normalizePartialDefinition( definition ) {
         if ( isSimpleValue( definition ) ) {
-            return variables.builder.resolveWireBoxMapping( definition ).getPartial;
+            return wirebox.getInstance( dsl = definition ).getPartial;
         }
 
         if ( isCustomFunction( definition ) || isClosure( definition ) ) {

--- a/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
@@ -154,6 +154,49 @@ component
         return mapping;
     }
 
+    function geoPoint( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "geo_point" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function geoShape( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "geo_shape" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function ip( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "ip" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function completion( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "completion" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function tokenCount( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "token_count" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function percolator( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "percolator" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function join( name, relations ) {
+        var mapping = variables.builder.newSimpleMapping( name, "join" );
+        mapping.relations( relations );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
     function partial( name, definition ) {
         definition = normalizePartialDefinition( definition );
         var mapping = definition( variables.builder.newBlueprint() );

--- a/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
@@ -10,8 +10,8 @@
 component accessors="true" {
 
     property name="wirebox" inject="wirebox";
+    property name="builder" inject="MappingBuilder@cbElasticSearch";
 
-    property name="builder";
     property name="properties";
 
     function init() {

--- a/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
@@ -1,0 +1,98 @@
+/**
+*
+* Elasticsearch Mapping Blueprint Object
+*
+* @package cbElasticsearch.models.mappings
+* @author Eric Peterson <eric@ortussolutions.com>
+* @license Apache v2.0 <http://www.apache.org/licenses/>
+*
+*/
+component
+	accessors="true"
+{
+
+    property name="builder";
+    property name="properties";
+
+    function init() {
+        variables.properties = [];
+        return this;
+    }
+
+    function text( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "text" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function keyword( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "keyword" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function long( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "long" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function integer( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "integer" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function short( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "short" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function byte( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "byte" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function double( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "double" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function float( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "float" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function halfFloat( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "half_float" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function scaledFloat( name, factor ) {
+        var mapping = variables.builder.newSimpleMapping( name, "scaled_float" );
+        mapping.scalingFactor( factor );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function object( name, callback ) {
+        var mapping = variables.builder.newObjectMapping( name, callback );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function toDSL() {
+        return {
+            "properties" = variables.properties.reduce( function( acc, prop ) {
+                acc[ prop.getName() ] = prop.toDSL();
+                return acc;
+            }, {} )
+        };
+    }
+
+}

--- a/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
@@ -86,6 +86,16 @@ component
         return mapping;
     }
 
+    function partial( name, definition ) {
+        definition = normalizePartialDefinition( definition );
+        var mapping = definition( variables.builder.newBlueprint() );
+        if ( ! isNull( name ) ) {
+            mapping.setName( name );
+        }
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
     function toDSL() {
         return {
             "properties" = variables.properties.reduce( function( acc, prop ) {
@@ -93,6 +103,18 @@ component
                 return acc;
             }, {} )
         };
+    }
+
+    private function normalizePartialDefinition( definition ) {
+        if ( isSimpleValue( definition ) ) {
+            return variables.builder.resolveWireBoxMapping( definition ).getPartial;
+        }
+
+        if ( isCustomFunction( definition ) || isClosure( definition ) ) {
+            return definition;
+        }
+
+        return definition.getPartial;
     }
 
 }

--- a/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBlueprint.cfc
@@ -80,8 +80,76 @@ component
         return mapping;
     }
 
+    function date( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "date" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function strictDate( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "date" );
+        mapping.format( "strict_date" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function boolean( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "boolean" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function binary( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "binary" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function integerRange( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "integer_range" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function floatRange( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "float_range" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function longRange( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "long_range" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function doubleRange( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "double_range" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function dateRange( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "date_range" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function ipRange( name ) {
+        var mapping = variables.builder.newSimpleMapping( name, "ip_range" );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
     function object( name, callback ) {
         var mapping = variables.builder.newObjectMapping( name, callback );
+        variables.properties.append( mapping );
+        return mapping;
+    }
+
+    function nested( name, callback ) {
+        var mapping = variables.builder.newObjectMapping( name, callback );
+        mapping.setType( "nested" );
         variables.properties.append( mapping );
         return mapping;
     }

--- a/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
@@ -32,6 +32,7 @@ component
         var mapping = wirebox.getInstance( "SimpleMapping@cbElasticSearch" );
         mapping.setName( name );
         mapping.setType( type );
+        mapping.setBuilder( this );
         return mapping;
     }
 

--- a/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
@@ -18,23 +18,19 @@ component singleton accessors="true" {
     }
 
     function newBlueprint() {
-        var blueprint = wirebox.getInstance( "MappingBlueprint@cbElasticSearch" );
-        blueprint.setBuilder( this );
-        return blueprint;
+        return wirebox.getInstance( "MappingBlueprint@cbElasticSearch" );
     }
 
     function newSimpleMapping( name, type ) {
         var mapping = wirebox.getInstance( "SimpleMapping@cbElasticSearch" );
         mapping.setName( name );
         mapping.setType( type );
-        mapping.setBuilder( this );
         return mapping;
     }
 
     function newObjectMapping( name, callback ) {
         var mapping = wirebox.getInstance( "ObjectMapping@cbElasticSearch" );
         mapping.setName( name );
-        mapping.setBuilder( this );
         mapping.setCallback( callback );
         return mapping;
     }

--- a/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
@@ -1,0 +1,37 @@
+/**
+*
+* Elasticsearch Mapping Builder Object
+*
+* @package cbElasticsearch.models.mappings
+* @author Eric Peterson <eric@ortussolutions.com>
+* @license Apache v2.0 <http://www.apache.org/licenses/>
+*
+*/
+component
+	accessors="true"
+{
+    property name="wirebox" inject="wirebox";
+
+    function create( callback ) {
+        var blueprint = wirebox.getInstance( "MappingBlueprint@cbElasticSearch" );
+        blueprint.setBuilder( this );
+        callback( blueprint );
+        return blueprint.toDSL();
+    }
+
+    function newSimpleMapping( name, type ) {
+        var mapping = wirebox.getInstance( "SimpleMapping@cbElasticSearch" );
+        mapping.setName( name );
+        mapping.setType( type );
+        return mapping;
+    }
+
+    function newObjectMapping( name, callback ) {
+        var mapping = wirebox.getInstance( "ObjectMapping@cbElasticSearch" );
+        mapping.setName( name );
+        mapping.setBuilder( this );
+        mapping.setCallback( callback );
+        return mapping;
+    }
+
+}

--- a/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
@@ -7,9 +7,8 @@
 * @license Apache v2.0 <http://www.apache.org/licenses/>
 *
 */
-component
-	accessors="true"
-{
+component singleton accessors="true" {
+
     property name="wirebox" inject="wirebox";
 
     function create( callback ) {

--- a/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
@@ -13,10 +13,19 @@ component
     property name="wirebox" inject="wirebox";
 
     function create( callback ) {
-        var blueprint = wirebox.getInstance( "MappingBlueprint@cbElasticSearch" );
-        blueprint.setBuilder( this );
+        var blueprint = newBlueprint();
         callback( blueprint );
         return blueprint.toDSL();
+    }
+
+    function newBlueprint() {
+        var blueprint = wirebox.getInstance( "MappingBlueprint@cbElasticSearch" );
+        blueprint.setBuilder( this );
+        return blueprint;
+    }
+
+    function resolveWireBoxMapping( dsl ) {
+        return wirebox.getInstance( dsl = dsl );
     }
 
     function newSimpleMapping( name, type ) {

--- a/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
+++ b/modules/cbelasticsearch/models/mappings/MappingBuilder.cfc
@@ -23,10 +23,6 @@ component singleton accessors="true" {
         return blueprint;
     }
 
-    function resolveWireBoxMapping( dsl ) {
-        return wirebox.getInstance( dsl = dsl );
-    }
-
     function newSimpleMapping( name, type ) {
         var mapping = wirebox.getInstance( "SimpleMapping@cbElasticSearch" );
         mapping.setName( name );

--- a/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
@@ -12,7 +12,6 @@ component
 	accessors="true"
 {
 
-    property name="builder";
     property name="callback";
 
     function toDSL() {

--- a/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
@@ -16,7 +16,9 @@ component
     property name="callback";
 
     function toDSL() {
-        return variables.builder.create( callback );
+        var result = variables.builder.create( callback );
+        result[ "type" ] = getType();
+        return result;
     }
 
 }

--- a/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
@@ -1,0 +1,22 @@
+/**
+*
+* Elasticsearch Object Mapping Object
+*
+* @package cbElasticsearch.models.mappings
+* @author Eric Peterson <eric@ortussolutions.com>
+* @license Apache v2.0 <http://www.apache.org/licenses/>
+*
+*/
+component
+    extends="AbstractMapping"
+	accessors="true"
+{
+
+    property name="builder";
+    property name="callback";
+
+    function toDSL() {
+        return variables.builder.create( callback );
+    }
+
+}

--- a/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/ObjectMapping.cfc
@@ -7,10 +7,7 @@
 * @license Apache v2.0 <http://www.apache.org/licenses/>
 *
 */
-component
-    extends="AbstractMapping"
-	accessors="true"
-{
+component extends="AbstractMapping" accessors="true" {
 
     property name="callback";
 

--- a/modules/cbelasticsearch/models/mappings/SimpleMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/SimpleMapping.cfc
@@ -7,10 +7,7 @@
 * @license Apache v2.0 <http://www.apache.org/licenses/>
 *
 */
-component
-    extends="AbstractMapping"
-	accessors="true"
-{
+component extends="AbstractMapping" accessors="true" {
 
     function toDSL() {
         var dsl = {

--- a/modules/cbelasticsearch/models/mappings/SimpleMapping.cfc
+++ b/modules/cbelasticsearch/models/mappings/SimpleMapping.cfc
@@ -1,0 +1,23 @@
+/**
+*
+* Elasticsearch Simple Mapping Object
+*
+* @package cbElasticsearch.models.mappings
+* @author Eric Peterson <eric@ortussolutions.com>
+* @license Apache v2.0 <http://www.apache.org/licenses/>
+*
+*/
+component
+    extends="AbstractMapping"
+	accessors="true"
+{
+
+    function toDSL() {
+        var dsl = {
+            "type" = variables.type
+        };
+        structAppend( dsl, variables.parameters );
+        return dsl;
+    }
+
+}

--- a/readme.md
+++ b/readme.md
@@ -29,40 +29,40 @@ _Note:  While only Elasticsearch 5.0 and above is supported, most of the REST-ba
 Configuration
 =============
 
-Once you have installed the module, you may add a custom configuration, specific to your environment, by adding an `elasticsearch` configuration object to your `Coldbox.cfc` configuration file.
+Once you have installed the module, you may add a custom configuration, specific to your environment, by adding an `cbElasticsearch` configuration object to your `moduleSettings` inside your `Coldbox.cfc` configuration file.
 
 By default the following are in place, without additional configuration:
 
 ```
 moduleSettings = {
-	"cbElasticsearch" : {
-		//The native client Wirebox DSL for the transport client
-		client="JestClient@cbElasticsearch",
-		// The default hosts - an array of host connections
-		//  - REST-based clients (e.g. JEST):  round robin connections will be used
-		//  - Socket-based clients (e.g. Transport):  cluster-aware routing used
-		hosts = [
-			//The default connection is made to http://127.0.0.1:9200
-			{
-				serverProtocol:'http',
-				serverName:'127.0.0.1',
-				//Socket-based connections will use 9300
-				serverPort:'9200'
-			}
-		],
-		// The default index
-		defaultIndex = "cbElasticsearch",
-		// The default number of shards to use when creating an index
-		defaultIndexShards = 3,
-		// The default number of index replicas to create
-		defaultIndexReplicas = 0,
-		// Whether to use separate threads for client transactions 
-		multiThreaded = true,
-		// The maximum number of connections allowed per route ( e.g. search URI endpoint )
-		maxConnectionsPerRoute = 10,
-		// The maxium number of connectsion, in total for all Elasticsearch requests
-		maxConnections = 100
-	}	
+    "cbElasticsearch" = {
+        // The native client Wirebox DSL for the transport client
+        client = "JestClient@cbElasticsearch",
+        // The default hosts - an array of host connections
+        //  - REST-based clients (e.g. JEST):  round robin connections will be used
+        //  - Socket-based clients (e.g. Transport):  cluster-aware routing used
+        hosts = [
+            // The default connection is made to http://127.0.0.1:9200
+            {
+                serverProtocol = "http",
+                serverName = "127.0.0.1",
+                // Socket-based connections will use 9300
+                serverPort = "9200"
+            }
+        ],
+        // The default index
+        defaultIndex = "cbElasticsearch",
+        // The default number of shards to use when creating an index
+        defaultIndexShards = 3,
+        // The default number of index replicas to create
+        defaultIndexReplicas = 0,
+        // Whether to use separate threads for client transactions
+        multiThreaded = true,
+        // The maximum number of connections allowed per route ( e.g. search URI endpoint )
+        maxConnectionsPerRoute = 10,
+        // The maxium number of connectsion, in total for all Elasticsearch requests
+        maxConnections = 100
+    }
 };
 ```
 
@@ -97,31 +97,29 @@ In short, indexes have a higher overhead and make the aggregation of search resu
 The `IndexBuilder` model assists with the creation and mapping of indexes. Mappings define the allowable data types within your documents and allow for better and more accurate search aggregations.  Let's say we have a book model that we intend to make searchable.  We are storing this in our `bookshop` index, under the type of `book`.  Let's create the index (if it doesn't exist) and map the type of `book`:
 
 ```
-var indexBuilder = getInstance( "IndexBuilder@cbElasticsearch" ).new( 
-	"bookshop",
-	{
-		"books":{
-			"_all":       { "enabled": false  },
-			"properties" : {
-				"title" : {"type":"string"},
-				"summary" : {"type":"string"},
-				"description" : {"type":"string"},
-				// denotes a nested struct with additional keys
-				"author" : {"type":"object"},
-				// date with specific format type
-				"publishDate": {
-					"type":"date",
-					//Our format will be: yyyy-mm-dd
-					"format" :"strict_date"
-				},
-				"edition" : {"type" : "integer"},
-				"ISBN" : {"type" : "integer"}
-			}
-		}
-	}
-
-).save()
-
+var indexBuilder = getInstance( "IndexBuilder@cbElasticsearch" ).new(
+    "bookshop",
+    {
+        "books" = {
+            "_all" = { "enabled" = false },
+            "properties" = {
+                "title" = { "type" = "string" },
+                "summary" = { "type" = "string" },
+                "description" = { "type" = "string" },
+                // denotes a nested struct with additional keys
+                "author" = { "type" = "object" },
+                // date with specific format type
+                "publishDate" = {
+                    "type" = "date",
+                    // our format will be = yyyy-mm-dd
+                    "format" = "strict_date"
+                },
+                "edition" = { "type" = "integer" },
+                "ISBN" = { "type" = "integer" }
+            }
+        }
+    }
+).save();
 ```
 
 
@@ -132,23 +130,23 @@ We can also add mappings after the `new()` method is called:
 var indexBuilder = getInstance( "IndexBuilder@cbElasticsearch" ).new( "bookshop" );
 // our mapping struct
 var booksMapping = {
-	"_all":       { "enabled": false  },
-	"properties" : {
-		"title" : {"type":"string"},
-		"summary" : {"type":"string"},
-		"description" : {"type":"string"},
-		// denotes a nested struct with additional keys
-		"author" : {"type":"object"},
-		// date with specific format type
-		"publishDate": {
-			"type":"date",
-			//Our format will be: yyyy-mm-dd
-			"format" :"strict_date"
-		},
-		"edition" : {"type" : "integer"},
-		"ISBN" : {"type" : "integer"}
-	}
-}
+    "_all" = { "enabled" = false },
+    "properties" = {
+        "title" = { "type" = "string" },
+        "summary" = { "type" = "string" },
+        "description" = { "type" = "string" },
+        // denotes a nested struct with additional keys
+        "author" = { "type" = "object" },
+        // date with specific format type
+        "publishDate" = {
+            "type" = "date",
+            // our format will be = yyyy-mm-dd
+            "format" = "strict_date"
+        },
+        "edition" = { "type" = "integer" },
+        "ISBN" = { "type" = "integer" }
+    }
+};
 
 // add the mapping and save
 indexBuilder.addMapping( "books", booksMapping ).save();
@@ -156,41 +154,41 @@ indexBuilder.addMapping( "books", booksMapping ).save();
 
 Note that, in the above examples, we are applying the index and mappings directly from within the object, itself, which is intuitive and fast. We could also pass the `IndexBuilder` object to the `Client@cbElasticsearch` instance's `applyIdex( required IndexBuilder indexBuilder )` method, if we wished.
 
-If an explicit mapping is not specified when the index is created, Elasticsearch will assign types when the first document is saved.  
+If an explicit mapping is not specified when the index is created, Elasticsearch will assign types when the first document is saved.
 
 We've also passed a simple struct in to the index properties.  If we wanted to add additional settings or configure replicas and shards, we could pass a more comprehensive struct, including a [range of settings](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/index-modules.html) to the `new()` method to do so:
 
 ```
-indexBuilder.new(  
-	"bookshop",
-	{
-		"settings" : {
-			"number_of_shards" : 10,
-			"number_of_replicas" : 2,
-			"auto_expand_replicas" :true,
-			"shard.check_on_startup" : "checksum"
-		},
-		"mappings" : {
-			"books":{
-				"_all": { "enabled": false  },
-				"properties" : {
-					"title" : {"type":"string"},
-					"summary" : {"type":"string"},
-					"description" : {"type":"string"},
-					// denotes a nested struct with additional keys
-					"author" : {"type":"object"},
-					// date with specific format type
-					"publishDate": {
-						"type":"date",
-						//Our format will be: yyyy-mm-dd
-						"format" :"strict_date"
-					},
-					"edition" : {"type" : "integer"},
-					"ISBN" : {"type" : "integer"}
-				}
-			}
-		}
-	}
+indexBuilder.new(
+    "bookshop",
+    {
+        "settings" = {
+            "number_of_shards" = 10,
+            "number_of_replicas" = 2,
+            "auto_expand_replicas" = true,
+            "shard.check_on_startup" = "checksum"
+        },
+        "mappings" = {
+            "books" = {
+                "_all" = { "enabled" = false },
+                "properties" = {
+                    "title" = { "type" = "string" },
+                    "summary" = { "type" = "string" },
+                    "description" = { "type" = "string" },
+                    // denotes a nested struct with additional keys
+                    "author" = { "type" = "object" },
+                    // date with specific format type
+                    "publishDate" = {
+                        "type" = "date",
+                        // our format will be = yyyy-mm-dd
+                        "format" = "strict_date"
+                    },
+                    "edition" = { "type" = "integer" },
+                    "ISBN" = { "type" = "integer" }
+                }
+            }
+        }
+    }
 
 );
 ```
@@ -205,30 +203,30 @@ indexBuilder.new(
 Managing Documents
 ==================
 
-Documents are the searchable, serialized objects within your indexes.  As noted above, documents may be assigned a type, allowing separation of schema, while still maintaining searchability across all documents in the index.   Within an index, each document is referenced by an `_id` value.  This `_id` may be set manually ( `document.setId()` ) or, if not provided will be auto-generated when the record is persisted.  Note that, if using numeric primary keys for your `_id` value, they will be cast as strings on serialization. 
+Documents are the searchable, serialized objects within your indexes.  As noted above, documents may be assigned a type, allowing separation of schema, while still maintaining searchability across all documents in the index.   Within an index, each document is referenced by an `_id` value.  This `_id` may be set manually ( `document.setId()` ) or, if not provided will be auto-generated when the record is persisted.  Note that, if using numeric primary keys for your `_id` value, they will be cast as strings on serialization.
 
 #### Creating a Document
 
-The `Document` model is the primary object for creating and working with Documents.  Let's say, again, we were going to create a `book` typed document in our index.  We would do so, by first creating a Documen object.
+The `Document` model is the primary object for creating and working with Documents.  Let's say, again, we were going to create a `book` typed document in our index.  We would do so, by first creating a `Document` object.
 
 ```
-var book = getInstance( "Document@cbElasticsearch" ).new( 
-	index="bookshop",
-	type="book",
-	properties = {
-		"title"      : "Elasticsearch for Coldbox",
-		"summary"    : "A great book on using Elasticsearch with the Coldbox framework",
-		"description": "A long descriptio with examples on why this book is great",
-		"author"     : {
-			"id"       : 1,
-			"firstName": "Jon",
-			"lastName" : "Clausen"
-		},
-		// date with specific format type
-		"publishDate": dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" ),
-		"edition"    : 1,
-		"ISBN"       : 123456789054321
-	}
+var book = getInstance( "Document@cbElasticsearch" ).new(
+    index = "bookshop",
+    type = "book",
+    properties = {
+        "title" = "Elasticsearch for Coldbox",
+        "summary" = "A great book on using Elasticsearch with the Coldbox framework",
+        "description" = "A long descriptio with examples on why this book is great",
+        "author" = {
+            "id" = 1,
+            "firstName" = "Jon",
+            "lastName" = "Clausen"
+        },
+        // date with specific format type
+        "publishDate" = dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" ),
+        "edition" = 1,
+        "ISBN" = 123456789054321
+    }
 );
 
 book.save();
@@ -243,12 +241,12 @@ document.populate( myBookStruct )
 or by individual setters:
 
 ```
-document.setValue( 
-	"author", 
-	{
-		"firstName" : "Jon",
-		"lastName"  : "Clausen"
-	} 
+document.setValue(
+    "author",
+    {
+        "firstName" = "Jon",
+        "lastName" = "Clausen"
+    }
 );
 ```
 
@@ -262,34 +260,32 @@ Using the `Document` object's accessors:
 
 ```
 var existingDocument = getInstance( "Document@Elasticsearch" )
-							.setIndex( 'bookshop' )
-							.setTitle( 'book' )
-							.setId( bookId )
-							.get(); 
+    .setIndex( "bookshop" )
+    .setTitle( "book" )
+    .setId( bookId )
+    .get();
 ```
 
-Calling the get() method with explicit arguments:
+Calling the `get()` method with explicit arguments:
 
 ```
 var existingDocument = getInstance( "Document@cbElasticsearch" )
-							.get( 
-								id    = bookId,
-								index = 'bookshop',
-								type  = 'book'
-							);
+    .get(
+        id = bookId,
+        index = "bookshop",
+        type = "book"
+    );
 ```
 
 Calling directly, using the same arguments, from the client:
 
 ```
 var existingDocument = getInstance( "Client@cbElasticsearch" )
-							.get( 
-								id    = bookId,
-								index = 'bookshop',
-								type  = 'book'
-							);
-
-
+    .get(
+        id = bookId,
+        index = "bookshop",
+        type = "book"
+    );
 ```
 
 #### Updating a Document
@@ -297,7 +293,7 @@ var existingDocument = getInstance( "Client@cbElasticsearch" )
 Once we've retrieved an existing document, we can simply update items through the `Document` instance and re-save them.
 
 ```
-existingDocument.populate( properties=myUpdatedBookStruct ).save()
+existingDocument.populate( properties = myUpdatedBookStruct ).save()
 ```
 
 You can also pass Document objects to the `Client`'s `save()` method:
@@ -311,20 +307,19 @@ getInstance( "Client@cbElasticsearch" ).save( existingDocument );
 Builk inserts and updates can be peformed by passing an array of `Document` objects to the Client's `saveAll()` method:
 
 ```
-var docments = [];
+var documents = [];
 
 for( var myStruct in myArray ){
-	var document = getInstance( "Document@cbElasticsearch" ).new( 
-		index      = myIndex,
-		type       = myType,
-		properties = myStruct
-	);
+    var document = getInstance( "Document@cbElasticsearch" ).new(
+        index = myIndex,
+        type = myType,
+        properties = myStruct
+    );
 
-	arrayAppend( documents, doucument );
+    arrayAppend( documents, doucument );
 }
 
 getInstance( "Client@cbElasticsearch" ).saveAll( documents );
-
 ```
 
 #### Deleting a Document
@@ -333,13 +328,13 @@ Deleting documents is similar to the process of saving.  The `Document` object m
 
 ```
 var document = getInstance( "Document@cbElasticsearch" )
-				.get( 
-					id    = documentId, 
-					index = "bookshop", 
-					type  = books 
-				);
+    .get(
+        id = documentId,
+        index = "bookshop",
+        type = books
+    );
 if( !isNull( document ) ){
-	document.delete();
+    document.delete();
 }
 ```
 
@@ -352,10 +347,10 @@ getInstance( "Client@cbElasticsearch" ).delete( myDocument );
 Finally, documents may also be deleted by query, using the `SearchBuilder` ( more below ):
 
 ```
-getInstance( "searchBuilder@cbElasticsearch" )
-		.new( index="bookshop", type="books" )
-		.match( "name", "Elasticsearch for Coldbox" )
-		.deleteAll();
+getInstance( "SearchBuilder@cbElasticsearch" )
+    .new( index="bookshop", type="books" )
+    .match( "name", "Elasticsearch for Coldbox" )
+    .deleteAll();
 ```
 
 
@@ -365,10 +360,10 @@ Searching Documents
 The `SearchBuilder` object offers an expressive syntax for crafting detailed searches with ranked results.  To perform a simple search for matching documents documents, using Elasticsearch's automatic scoring, we would use the `SearchBuilder` like so:
 
 ```
-var searchResults = getInstance( "searchBuilder@cbElasticsearch" )
-						.new( index="bookshop", type="books" )
-						.match( "name", "Elasticsearch" )
-						.execute();
+var searchResults = getInstance( "SearchBuilder@cbElasticsearch" )
+    .new( index="bookshop", type="books" )
+    .match( "name", "Elasticsearch" )
+    .execute();
 ```
 
 By default this search will return an array of `Document` objects ( or an empty array if no results are found ), with a descending match score as the sort.
@@ -377,10 +372,10 @@ To output the results of our search, we would use a loop, accessing the `Documen
 
 ```
 for( var resultDocument in searchResult ){
-	var resultScore     = resultDocument.getScore();
-	var documentMemento = resultDocument.getMemento();
-	var bookName        = documentMemento.name;
-	var bookDescription = documentMemento.description;
+    var resultScore = resultDocument.getScore();
+    var documentMemento = resultDocument.getMemento();
+    var bookName = documentMemento.name;
+    var bookDescription = documentMemento.description;
 }
 ```
 
@@ -388,9 +383,9 @@ The "memento" is our structural representation of the document. We can also use 
 
 ```
 for( var resultDocument in searchResult ){
-	var resultScore     = resultDocument.getScore();
-	var bookName        = resultDocument.getValue( "name" );
-	var bookDescription = resultDoument.getValue( "description" );
+    var resultScore = resultDocument.getScore();
+    var bookName = resultDocument.getValue( "name" );
+    var bookDescription = resultDoument.getValue( "description" );
 }
 ```
 
@@ -402,13 +397,13 @@ for( var resultDocument in searchResult ){
 The `term()` method allows a means of specifying an exact match of all documents in the search results.  An example use case might be only to search for active documents:
 
 ```
-searchBuilder.term( 'isActive', 1 );
+searchBuilder.term( "isActive", 1 );
 ```
 
 Or a date:
 
 ```
-searchBuilder.term( 'publishDate', '2017-05-13' );
+searchBuilder.term( "publishDate", "2017-05-13" );
 ```
 
 #### Boosting individual matches
@@ -417,50 +412,48 @@ The `match()` method of the `SearchBuilder` also allows for a `boost` argument. 
 
 ```
 searchBuilder
-		.match( "shortDescription", "Elasticsearch" )
-		.match( "description", "Elasticsearch" )
-		.match( 
-			name="name", 
-			value="Elasticsearch",
-			boost=.5
-		);
+    .match( "shortDescription", "Elasticsearch" )
+    .match( "description", "Elasticsearch" )
+    .match(
+        name = "name",
+        value = "Elasticsearch",
+        boost = 0.5
+    );
 ```
 
 In the above example, documents with a `name` field containing "Elasticsearch" would be boosted in score higher than those which only find the value in the short or long description.
 
 #### Advanced Query DSL
 
-The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing detailed configuration of queries, if the basic `match()`, `sort()` and `aggregate()` methods are not enough to meet your needs. There are several methods to provide the raw query language to the Search Builder.  One is during instantiation.  
+The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html) allowing detailed configuration of queries if the basic `match()`, `sort()` and `aggregate()` methods are not enough to meet your needs. There are several methods to provide the raw query language to the Search Builder.  One is during instantiation.
 
-In the following we are looking for matches of active records with "Elasticsearch" in the name, description, or shortDescription fields. We are also looking for a phrase match of "is awesome" and are boosting the score of the applicable document, if found.
-
+In the following we are looking for matches of active records with "Elasticsearch" in the `name`, `description`, or `shortDescription` fields. We are also looking for a phrase match of "is awesome" and are boosting the score of the applicable document, if found.
 
 ```
 var search = getInstance( "SearchBuilder@cbElasticsearch" )
-					.new( 
-						index = "bookshop",
-						type = "books",
-						properties = {
-							"query":{
-								"term" : {
-									"isActive" : 1
-								},
-								"match" : {
-									"name"            : "Elasticsearch",
-									"description"     : "Elasticsearch",
-									"shortDescription": "Elasticsearch"
-								},
-								"match_phrase" : {
-									"description" : {
-										"query" : "is awesome",
-										"boost" : 2
-									}
-								},
-
-							}
-						}
-					)
-					.execute();
+    .new(
+        index = "bookshop",
+        type = "books",
+        properties = {
+            "query" = {
+                "term" = {
+                    "isActive" = 1
+                },
+                "match" = {
+                    "name" = "Elasticsearch",
+                    "description" = "Elasticsearch",
+                    "shortDescription" = "Elasticsearch"
+                },
+                "match_phrase" = {
+                    "description" = {
+                        "query" = "is awesome",
+                        "boost" = 2
+                    }
+                }
+            }
+        }
+    )
+    .execute();
 ```
 
 For more information on Elasticsearch query DSL, the [Search in Depth Documentation](https://www.elastic.co/guide/en/elasticsearch/guide/current/search-in-depth.html) is an excellent starting point.

--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,7 @@ var booksMapping = {
 indexBuilder.addMapping( "books", booksMapping ).save();
 ```
 
-Note that, in the above examples, we are applying the index and mappings directly from within the object, itself, which is intuitive and fast. We could also pass the `IndexBuilder` object to the `Client@cbElasticsearch` instance's `applyIdex( required IndexBuilder indexBuilder )` method, if we wished.
+Note that, in the above examples, we are applying the index and mappings directly from within the object, itself, which is intuitive and fast. We could also pass the `IndexBuilder` object to the `Client@cbElasticsearch` instance's `applyIndex( required IndexBuilder indexBuilder )` method, if we wished.
 
 If an explicit mapping is not specified when the index is created, Elasticsearch will assign types when the first document is saved.
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Requirements
 
 * Coldbox >= v4.5
 * Elasticsearch  >= v5.0
-* Lucee >= v4.5 or Adobe Coldfusion >= v10
+* Lucee >= v4.5 or Adobe Coldfusion >= v11
 
 _Note:  While only Elasticsearch 5.0 and above is supported, most of the REST-based methods will work on previous versions.  A notable exception is the multi-delete methods, which use the [delete by query](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-delete-by-query.html) functionality of ES5.  As such, Cachebox and Logbox functionality would be limited._
 

--- a/readme.md
+++ b/readme.md
@@ -484,6 +484,19 @@ While our documents would still be scored, the results order would be changed to
 * `term(string name, any value, [numeric boost])` - Adds an exact value restriction ( elasticsearch: term ) to the query.
 * `aggregation(string name, struct options)`  - Adds an aggregation directive to the search parameters.
 
+## Tests
+
+To run the test suite you need a running instance of ElasticSearch.  We have provided a `docker-compose.yml` file in
+the root of the repo to make this easy as possible.  Run `docker-compose up` in the root of the project and open
+`http://localhost:8080/tests/runner.cfm` to run the tests.
+
+If you would prefer to set this up yourself, make sure you start this app with the correct environment variables set:
+
+```ini
+ELASTICSEARCH_PROTOCOL=http
+ELASTICSEARCH_HOST=127.0.0.1
+ELASTICSEARCH_PORT=9200
+```
 
 ********************************************************************************
 Copyright Since 2005 ColdBox Framework by Luis Majano and Ortus Solutions, Corp

--- a/tests/Application.cfc
+++ b/tests/Application.cfc
@@ -18,17 +18,19 @@ component{
 	//example CF Mappings
 	this.mappings[ "/cbElasticsearch" ] 	= rootPath & "modules/elasticsearch";
 	this.mappings[ "/cbjavaloader" ] 	= rootPath & "modules/cbjavaloader";
-	
+
 	// any orm definitions go here.
 
 	function onRequestStart(){
+        // applicationStop();
+        // abort;
 		// Clear out the previous framework objects so that the first spec with `loadColdbox` set to `true` will reload them
-		
+
 		if( structKeyExists( url, "persistColdbox" ) && !url.persistColdbox ){
 
 			structDelete( application, "cbController" );
-			structDelete( application, "wirebox" );	
-		
+			structDelete( application, "wirebox" );
+
 		}
 
 	}

--- a/tests/resources/UserPartial.cfc
+++ b/tests/resources/UserPartial.cfc
@@ -1,0 +1,13 @@
+component singleton {
+
+    function getPartial( mapping ) {
+        return mapping.object( "user", function( mapping ) {
+            mapping.integer( "age" );
+            mapping.object( "name", function( mapping ) {
+                mapping.text( "first" );
+                mapping.text( "last" );
+            } );
+        } );
+    }
+
+}

--- a/tests/specs/unit/IndexBuilderTest.cfc
+++ b/tests/specs/unit/IndexBuilderTest.cfc
@@ -1,11 +1,11 @@
 component extends="coldbox.system.testing.BaseTestCase"{
-	
+
 	function beforeAll(){
 
 		this.loadColdbox=true;
 
 		setup();
-		
+
 		variables.model = getWirebox().getInstance( "IndexBuilder@cbElasticSearch" );
 
 		variables.testIndexName = lcase("IndexBuilderTests");
@@ -15,8 +15,8 @@ component extends="coldbox.system.testing.BaseTestCase"{
 	}
 
 	function afterAll(){
-		
-		//variables.model.getClient().deleteIndex( variables.testIndexName );	
+
+		//variables.model.getClient().deleteIndex( variables.testIndexName );
 
 		super.afterAll();
 	}
@@ -32,7 +32,7 @@ component extends="coldbox.system.testing.BaseTestCase"{
 				expect( structIsEmpty( newIndex.getMappings() ) ).toBeTrue();
 				expect( isNull( newIndex.getSettings() ) ).toBeTrue();
 
-				
+
 			});
 
 			it( "Tests new() with a full properties struct", function(){
@@ -64,7 +64,26 @@ component extends="coldbox.system.testing.BaseTestCase"{
 				expect( structIsEmpty( newIndex.getMappings() ) ).toBeFalse();
 				expect( newIndex.getIndexName() ).toBe( variables.testIndexName );
 
-			});
+            });
+
+            it( "Tests new() with a callback for the builder syntax", function() {
+				var newIndex = variables.model.new( name=variables.testIndexName, properties=function( builder ) {
+                    return {
+                        "testdocs" = builder.create( function( mapping ) {
+                            mapping.text( "title" );
+                            mapping.date( "createdTime" ).format( "date_time_no_millis" );
+                        } )
+                    };
+                }, settings = { "number_of_shards" = 5, "number_of_replicas" = 2 } );
+
+				expect( newIndex.getSettings() ).toBeStruct();
+				expect( structIsEmpty( newIndex.getSettings() ) ).toBeFalse();
+				expect( newIndex.getMappings() ).toBeStruct();
+				expect( structIsEmpty( newIndex.getMappings() ) ).toBeFalse();
+                expect( newIndex.getIndexName() ).toBe( variables.testIndexName );
+                expect( newIndex.getMappings() ).notToBeEmpty();
+                expect( newIndex.getMappings() ).toHaveKey( "testdocs" );
+			} );
 
 			it( "Tests the save() method ability to create an index", function(){
 				//create our new index
@@ -84,9 +103,9 @@ component extends="coldbox.system.testing.BaseTestCase"{
 									};
 
 
-				var newIndex = variables.model.new( 
+				var newIndex = variables.model.new(
 											name=variables.testIndexName,
-											properties=indexSettings 
+											properties=indexSettings
 										);
 
 				expect( newIndex.save() ).toBeTrue();
@@ -96,7 +115,7 @@ component extends="coldbox.system.testing.BaseTestCase"{
 			});
 
 			it( "Tests the ability to reset the index builder", function(){
-					
+
 				variables.model.reset();
 
 				expect( variables.model.getMappings() ).toBeStruct();

--- a/tests/specs/unit/MappingBuilderTest.cfc
+++ b/tests/specs/unit/MappingBuilderTest.cfc
@@ -148,7 +148,148 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     expect( actual ).toBe( { "properties" = expected } );
                 } );
 
-                it( "nested objects", function() {
+                it( "date", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.date( "createdDate" );
+                    } );
+
+                    var expected = {
+                        "createdDate" = {
+                            "type" = "date"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "strictDate", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.strictDate( "publishedDate" );
+                    } );
+
+                    var expected = {
+                        "publishedDate" = {
+                            "type" = "date",
+                            "format" = "strict_date"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "boolean", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.boolean( "isSubscribed" );
+                    } );
+
+                    var expected = {
+                        "isSubscribed" = {
+                            "type" = "boolean"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "binary", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.binary( "blob" );
+                    } );
+
+                    var expected = {
+                        "blob" = {
+                            "type" = "binary"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "integerRange", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.integerRange( "expectedAtendees" );
+                    } );
+
+                    var expected = {
+                        "expectedAtendees" = {
+                            "type" = "integer_range"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "floatRange", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.floatRange( "standardDeviation" );
+                    } );
+
+                    var expected = {
+                        "standardDeviation" = {
+                            "type" = "float_range"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "longRange", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.longRange( "averageViews" );
+                    } );
+
+                    var expected = {
+                        "averageViews" = {
+                            "type" = "long_range"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "doubleRange", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.doubleRange( "over_under" );
+                    } );
+
+                    var expected = {
+                        "over_under" = {
+                            "type" = "double_range"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "dateRange", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.dateRange( "timeframe" );
+                    } );
+
+                    var expected = {
+                        "timeframe" = {
+                            "type" = "date_range"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "ipRange", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.ipRange( "ip_allowlist" );
+                    } );
+
+                    var expected = {
+                        "ip_allowlist" = {
+                            "type" = "ip_range"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "object", function() {
                     var actual = builder.create( function( mapping ) {
                         mapping.keyword( "region" );
                         mapping.object( "manager", function( mapping ) {
@@ -163,14 +304,37 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     var expected = {
                         "region" = { "type" = "keyword" },
                         "manager" = {
+                            "type" = "object",
                             "properties" = {
                                 "age" = { "type" = "integer" },
                                 "name" = {
+                                    "type" = "object",
                                     "properties" = {
                                         "first" = { "type" = "text" },
                                         "last" = { "type" = "text" }
                                     }
                                 }
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "nested", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.nested( "name", function( mapping ) {
+                            mapping.text( "first" );
+                            mapping.text( "last" );
+                        } );
+                    } );
+
+                    var expected = {
+                        "name" = {
+                            "type" = "nested",
+                            "properties" = {
+                                "first" = { "type" = "text" },
+                                "last" = { "type" = "text" }
                             }
                         }
                     };
@@ -261,9 +425,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
                     var expected = {
                         "manager" = {
+                            "type" = "object",
                             "properties" = {
                                 "age" = { "type" = "integer" },
                                 "name" = {
+                                    "type" = "object",
                                     "properties" = {
                                         "first" = { "type" = "text" },
                                         "last" = { "type" = "text" }
@@ -272,9 +438,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
                             }
                         },
                         "user" = {
+                            "type" = "object",
                             "properties" = {
                                 "age" = { "type" = "integer" },
                                 "name" = {
+                                    "type" ="object",
                                     "properties" = {
                                         "first" = { "type" = "text" },
                                         "last" = { "type" = "text" }
@@ -295,9 +463,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
                     var expected = {
                         "manager" = {
+                            "type" = "object",
                             "properties" = {
                                 "age" = { "type" = "integer" },
                                 "name" = {
+                                    "type" = "object",
                                     "properties" = {
                                         "first" = { "type" = "text" },
                                         "last" = { "type" = "text" }
@@ -306,9 +476,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
                             }
                         },
                         "user" = {
+                            "type" = "object",
                             "properties" = {
                                 "age" = { "type" = "integer" },
                                 "name" = {
+                                    "type" = "object",
                                     "properties" = {
                                         "first" = { "type" = "text" },
                                         "last" = { "type" = "text" }
@@ -331,9 +503,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
                     var expected = {
                         "manager" = {
+                            "type" = "object",
                             "properties" = {
                                 "age" = { "type" = "integer" },
                                 "name" = {
+                                    "type" = "object",
                                     "properties" = {
                                         "first" = { "type" = "text" },
                                         "last" = { "type" = "text" }
@@ -342,9 +516,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
                             }
                         },
                         "user" = {
+                            "type" = "object",
                             "properties" = {
                                 "age" = { "type" = "integer" },
                                 "name" = {
+                                    "type" = "object",
                                     "properties" = {
                                         "first" = { "type" = "text" },
                                         "last" = { "type" = "text" }

--- a/tests/specs/unit/MappingBuilderTest.cfc
+++ b/tests/specs/unit/MappingBuilderTest.cfc
@@ -554,6 +554,28 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
                     expect( actual ).toBe( { "properties" = expected } );
                 } );
+
+                it( "multi-fields are full mapping blueprint instances", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.text( "text" ).fields( function( mapping ) {
+                            mapping.text( "english" ).analyzer( "english" );
+                        } );
+                    } );
+
+                    var expected = {
+                        "text" = {
+                            "type" = "text",
+                            "fields": {
+                                "english" = {
+                                    "type" = "text",
+                                    "analyzer" = "english"
+                                }
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
             } );
 
             describe( "partials", function() {

--- a/tests/specs/unit/MappingBuilderTest.cfc
+++ b/tests/specs/unit/MappingBuilderTest.cfc
@@ -708,12 +708,6 @@ component extends="coldbox.system.testing.BaseTestCase" {
 		} );
     }
 
-    private function testCase( callback, expected ) {
-        // var builder = getBuilder();
-        // var dsl = callback( builder );
-        // expect( dsl ).toBe( { "properties" = expected } );
-    }
-
     private function getBuilder() {
         return getInstance( "MappingBuilder@cbElasticSearch" );
     }

--- a/tests/specs/unit/MappingBuilderTest.cfc
+++ b/tests/specs/unit/MappingBuilderTest.cfc
@@ -485,6 +485,30 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     expect( actual ).toBe( { "properties" = expected } );
                 } );
 
+                it( "can add a single parameter", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.text( "full_name" ).addParameter(
+                            "index_prefixes",
+                            {
+                                "min_chars" = 1,
+                                "max_chars" = 10
+                            }
+                        );
+                    } );
+
+                    var expected = {
+                        "full_name" = {
+                            "type" = "text",
+                            "index_prefixes" = {
+                                "min_chars" = 1,
+                                "max_chars" = 10
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
                 it( "can set all parameters at once", function() {
                     var actual = builder.create( function( mapping ) {
                         mapping.text( "full_name" ).setParameters( {

--- a/tests/specs/unit/MappingBuilderTest.cfc
+++ b/tests/specs/unit/MappingBuilderTest.cfc
@@ -1,0 +1,257 @@
+component extends="coldbox.system.testing.BaseTestCase" {
+
+	function run() {
+		describe( "MappingBuilder", function() {
+            beforeEach( function() {
+                variables.builder = getBuilder();
+            } );
+
+            describe( "property types", function() {
+                it( "text", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.text( "full_name" );
+                    } );
+
+                    var expected = {
+                        "full_name" = {
+                            "type" = "text"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "keyword", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.keyword( "tags" );
+                    } );
+
+                    var expected = {
+                        "tags" = {
+                            "type" = "keyword"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "long", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.long( "views" );
+                    } );
+
+                    var expected = {
+                        "views" = {
+                            "type" = "long"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "integer", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.integer( "bytes" );
+                    } );
+
+                    var expected = {
+                        "bytes" = {
+                            "type" = "integer"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "short", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.short( "year" );
+                    } );
+
+                    var expected = {
+                        "year" = {
+                            "type" = "short"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "byte", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.byte( "age" );
+                    } );
+
+                    var expected = {
+                        "age" = {
+                            "type" = "byte"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "double", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.double( "discount" );
+                    } );
+
+                    var expected = {
+                        "discount" = {
+                            "type" = "double"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "float", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.float( "tax" );
+                    } );
+
+                    var expected = {
+                        "tax" = {
+                            "type" = "float"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "halfFloat", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.halfFloat( "proprtion" );
+                    } );
+
+                    var expected = {
+                        "proprtion" = {
+                            "type" = "half_float"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "scaledFloat", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.scaledFloat( "price", 100 );
+                    } );
+
+                    var expected = {
+                        "price" = {
+                            "type" = "scaled_float",
+                            "scaling_factor": 100
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "nested objects", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.keyword( "region" );
+                        mapping.object( "manager", function( mapping ) {
+                            mapping.integer( "age" );
+                            mapping.object( "name", function( mapping ) {
+                                mapping.text( "first" );
+                                mapping.text( "last" );
+                            } );
+                        } );
+                    } );
+
+                    var expected = {
+                        "region" = { "type" = "keyword" },
+                        "manager" = {
+                            "properties" = {
+                                "age" = { "type" = "integer" },
+                                "name" = {
+                                    "properties" = {
+                                        "first" = { "type" = "text" },
+                                        "last" = { "type" = "text" }
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+            } );
+
+            describe( "parameters", function() {
+                it( "forwards on further method calls as parameters", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.text( "full_name" ).index( false );
+                    } );
+
+                    var expected = {
+                        "full_name" = {
+                            "type" = "text",
+                            "index" = false
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "converts camelCase to snake_case", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.text( "full_name" ).indexPrefixes( {
+                            "min_chars" = 1,
+                            "max_chars" = 10
+                        } );
+                    } );
+
+                    var expected = {
+                        "full_name" = {
+                            "type" = "text",
+                            "index_prefixes" = {
+                                "min_chars" = 1,
+                                "max_chars" = 10
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "can set all parameters at once", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.text( "full_name" ).setParameters( {
+                            "fielddata" = true,
+                            "index_prefixes" = {
+                                "min_chars" = 1,
+                                "max_chars" = 10
+                            }
+                        } );
+                    } );
+
+                    var expected = {
+                        "full_name" = {
+                            "type" = "text",
+                            "fielddata" = true,
+                            "index_prefixes" = {
+                                "min_chars" = 1,
+                                "max_chars" = 10
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+            } );
+		} );
+    }
+
+    private function testCase( callback, expected ) {
+        // var builder = getBuilder();
+        // var dsl = callback( builder );
+        // expect( dsl ).toBe( { "properties" = expected } );
+    }
+
+    private function getBuilder() {
+        return getInstance( "MappingBuilder@cbElasticSearch" );
+    }
+
+}

--- a/tests/specs/unit/MappingBuilderTest.cfc
+++ b/tests/specs/unit/MappingBuilderTest.cfc
@@ -241,6 +241,122 @@ component extends="coldbox.system.testing.BaseTestCase" {
                     expect( actual ).toBe( { "properties" = expected } );
                 } );
             } );
+
+            describe( "partials", function() {
+                it( "can use a callback", function() {
+                    var partialFn = function( mapping ) {
+                        return mapping.object( "user", function( mapping ) {
+                            mapping.integer( "age" );
+                            mapping.object( "name", function( mapping ) {
+                                mapping.text( "first" );
+                                mapping.text( "last" );
+                            } );
+                        } );
+                    };
+
+                    var actual = builder.create( function( mapping ) {
+                        mapping.partial( "manager", partialFn );
+                        mapping.partial( definition = partialFn );
+                    } );
+
+                    var expected = {
+                        "manager" = {
+                            "properties" = {
+                                "age" = { "type" = "integer" },
+                                "name" = {
+                                    "properties" = {
+                                        "first" = { "type" = "text" },
+                                        "last" = { "type" = "text" }
+                                    }
+                                }
+                            }
+                        },
+                        "user" = {
+                            "properties" = {
+                                "age" = { "type" = "integer" },
+                                "name" = {
+                                    "properties" = {
+                                        "first" = { "type" = "text" },
+                                        "last" = { "type" = "text" }
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "can use a wirebox dsl", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.partial( "manager", "tests.resources.UserPartial" );
+                        mapping.partial( definition = "tests.resources.UserPartial" );
+                    } );
+
+                    var expected = {
+                        "manager" = {
+                            "properties" = {
+                                "age" = { "type" = "integer" },
+                                "name" = {
+                                    "properties" = {
+                                        "first" = { "type" = "text" },
+                                        "last" = { "type" = "text" }
+                                    }
+                                }
+                            }
+                        },
+                        "user" = {
+                            "properties" = {
+                                "age" = { "type" = "integer" },
+                                "name" = {
+                                    "properties" = {
+                                        "first" = { "type" = "text" },
+                                        "last" = { "type" = "text" }
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "can use a component with a getPartial methods", function() {
+                    var userPartial = new tests.resources.UserPartial();
+
+                    var actual = builder.create( function( mapping ) {
+                        mapping.partial( "manager", userPartial );
+                        mapping.partial( definition = userPartial );
+                    } );
+
+                    var expected = {
+                        "manager" = {
+                            "properties" = {
+                                "age" = { "type" = "integer" },
+                                "name" = {
+                                    "properties" = {
+                                        "first" = { "type" = "text" },
+                                        "last" = { "type" = "text" }
+                                    }
+                                }
+                            }
+                        },
+                        "user" = {
+                            "properties" = {
+                                "age" = { "type" = "integer" },
+                                "name" = {
+                                    "properties" = {
+                                        "first" = { "type" = "text" },
+                                        "last" = { "type" = "text" }
+                                    }
+                                }
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+            } );
 		} );
     }
 

--- a/tests/specs/unit/MappingBuilderTest.cfc
+++ b/tests/specs/unit/MappingBuilderTest.cfc
@@ -341,6 +341,111 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
                     expect( actual ).toBe( { "properties" = expected } );
                 } );
+
+                it( "geoPoint", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.geoPoint( "location" );
+                    } );
+
+                    var expected = {
+                        "location" = {
+                            "type" = "geo_point"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "geoShape", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.geoShape( "location" );
+                    } );
+
+                    var expected = {
+                        "location" = {
+                            "type" = "geo_shape"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "ip", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.ip( "ip_address" );
+                    } );
+
+                    var expected = {
+                        "ip_address" = {
+                            "type" = "ip"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "completion", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.completion( "suggest" );
+                    } );
+
+                    var expected = {
+                        "suggest" = {
+                            "type" = "completion"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "tokenCount", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.tokenCount( "length" );
+                    } );
+
+                    var expected = {
+                        "length" = {
+                            "type" = "token_count"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "percolator", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.percolator( "query" );
+                    } );
+
+                    var expected = {
+                        "query" = {
+                            "type" = "percolator"
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "join", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.join( "my_join_field", {
+                            "question": [ "answer", "comment" ],
+                            "answer": "vote"
+                        } );
+                    } );
+
+                    var expected = {
+                        "my_join_field" = {
+                            "type" = "join",
+                            "relations": {
+                                "question": [ "answer", "comment" ],
+                                "answer": "vote"
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
             } );
 
             describe( "parameters", function() {
@@ -398,6 +503,27 @@ component extends="coldbox.system.testing.BaseTestCase" {
                             "index_prefixes" = {
                                 "min_chars" = 1,
                                 "max_chars" = 10
+                            }
+                        }
+                    };
+
+                    expect( actual ).toBe( { "properties" = expected } );
+                } );
+
+                it( "can create multi-fields", function() {
+                    var actual = builder.create( function( mapping ) {
+                        mapping.text( "city" ).fields( function( mapping ) {
+                            mapping.keyword( "raw" );
+                        } );
+                    } );
+
+                    var expected = {
+                        "city" = {
+                            "type" = "text",
+                            "fields": {
+                                "raw" = {
+                                    "type" = "keyword"
+                                }
                             }
                         }
                     };

--- a/tests/test.properties
+++ b/tests/test.properties
@@ -3,3 +3,4 @@ url.runners.lucee@5=http://127.0.0.1:50685/tests/runner.cfm?
 url.runners.adobe@10=http://127.0.0.1:49610/tests/runner.cfm?
 url.runners.adobe@11=http://127.0.0.1:49611/tests/runner.cfm?
 url.runners.adobe@2016=http://127.0.0.1:49616/tests/runner.cfm?
+url.runners.adobe@2018=http://127.0.0.1:49616/tests/runner.cfm?


### PR DESCRIPTION
This PR introduces a new mapping builder.

## Mapping Builder

This builder can be accessed by injecting it into your components:

```
component {
    property name="builder" inject="MappingBuilder@cbElasticSearch";
}
```

The `new` method of the `IndexBuilder` also accepts a closure as the second (`properties`) argument.  If a closure is passed, a `MappingBuilder` instance is passed as an argument to the closure:

```
indexBuilder.new( "elasticsearch", function( builder ) {
    return {
        "_doc" = builder.create( function( mapping ) {
            mapping.text( "title" );
            mapping.date( "createdTime" ).format( "date_time_no_millis" );
        } )
    };
} );
```

The `MappingBuilder` has one primary method: `create`.  `create` takes a callback with a `MappingBlueprint` object, usually aliased as `mapping`.

## Mapping Blueprint

The `MappingBlueprint` gives a fluent api to defining a mapping.  It has methods for all the ElasticSearch mapping types:

```
builder.create( function( mapping ) {
    mapping.text( "title" );
    mapping.date( "createdTime" ).format( "date_time_no_millis" );
    mapping.object( "user", function( mapping ) {
        mapping.keyword( "gender" );
        mapping.integer( "age" );
        mapping.object( "name", function( mapping ) {
            mapping.text( "first" );
            mapping.text( "last" );
        } );
    } );
} )
```

As seen above, `object` expects a closure which will be provided another `MappingBlueprint`.  The results will be set as the `properties` of the `object` call.

## Parameters

Parameters can be chained on to a mapping type.  Parameters are set using `onMissingMethod` and will use the method name (as snake case) as the parameter name and the first argument passed as the parameter value.

```
builder.create( function( mapping ) {
    mapping.text( "title" ).fielddata( true );
    mapping.date( "createdTime" ).format( "date_time_no_millis" );
} )
```

> You can also add parameters using the `addParameter( string name, any value )` or `setParameters( struct map )` methods.

The only exception to the parameters functions is `fields` which expects a closure argument and allows you to create multiple field definitions for a mapping.

```
builder.create( function( mapping ) {
    mapping.text( "city" ).fields( function( mapping ) {
        mapping.keyword( "raw" );
    } );
} );
```

## Partials

The Mapping Blueprint also has a way to reuse mappings.  Say for instance you have a `user` mapping that gets repeated for managers as well.

The partial method accepts three different kinds of arguments:
1. A closure
1. A component with a `getPartial` method
1. A WireBox mapping to a component with a `getPartial` method

```
var partialFn = function( mapping ) {
    return mapping.object( "user", function( mapping ) {
        mapping.integer( "age" );
        mapping.object( "name", function( mapping ) {
            mapping.text( "first" );
            mapping.text( "last" );
        } );
    } );
};

builder.create( function( mapping ) {
    mapping.partial( "manager", partialFn );
    mapping.partial( definition = partialFn ); // uses the partial's defined name, `user` in this case
} );
```

The first approach is great for partials that are reused in the same index.
The second two approaches work better for partials that are reused across indexes.

TODO:
+ [ ] Add docs to README