### PR TITLE
Expand terms methods to include `filterTerm` and `terms`

### DIFF
--- a/modules/cbelasticsearch/models/SearchBuilder.cfc
+++ b/modules/cbelasticsearch/models/SearchBuilder.cfc
@@ -249,6 +249,45 @@ component accessors="true" {
 
     }
 
+    /**
+    * Adds an exact value restriction ( elasticsearch: term ) to the query
+    * @name 		string 		the name of the parameter to match
+    * @value 		any 		the value of the parameter to match
+    * @boost 		numeric		A numeric boost option for any exact matches
+    *
+    **/
+    SearchBuilder function terms(
+        required string name,
+        required any value,
+        numeric boost
+    ){
+        if ( ! isArray( arguments.value ) ) {
+            arguments.value = listToArray( arguments.value );
+        }
+
+        if( !structKeyExists( variables.query, "terms" ) ){
+
+            variables.query[ "terms" ] = {};
+
+        }
+
+        if( !isNull( arguments.boost ) ){
+
+            variables.query[ "terms" ][ arguments.name ] = {
+                "value" : arguments.value,
+                "boost" : javacast( "float", arguments.boost )
+            };
+
+        } else {
+
+            variables.query[ "terms" ][ arguments.name ] = arguments.value;
+
+        }
+
+        return this;
+
+    }
+
     function filterTerm( required string name, required any value ) {
         param variables.query.bool = {};
         param variables.query.bool.filter = {};

--- a/modules/cbelasticsearch/models/SearchBuilder.cfc
+++ b/modules/cbelasticsearch/models/SearchBuilder.cfc
@@ -249,6 +249,18 @@ component accessors="true" {
 
     }
 
+    function filterTerm( required string name, required any value ) {
+        param variables.query.bool = {};
+        param variables.query.bool.filter = {};
+        param variables.query.bool.filter.bool = {};
+        param variables.query.bool.filter.bool.must = [];
+        arrayAppend( variables.query.bool.filter.bool.must, {
+            "term": {
+                "#name#": value
+            }
+        });
+    }
+
     function filterTerms(
         required string name,
         required any value
@@ -256,7 +268,7 @@ component accessors="true" {
         if( isSimpleValue( value ) ) arguments.value = listToArray( value );
 
         if( isArray( value ) && arrayLen( value ) == 1 ){
-            return term( name=arguments.name, value=value[ 1 ] );
+            return filterTerm( name=arguments.name, value=value[ 1 ] );
         }
 
         param variables.query.bool = {};

--- a/tests/specs/unit/SearchBuilderTest.cfc
+++ b/tests/specs/unit/SearchBuilderTest.cfc
@@ -374,7 +374,20 @@ component extends="coldbox.system.testing.BaseTestCase"{
 
 			 	expect( searchResult ).toBeComponent();
 
-			});
+            });
+
+            it( "Tests the terms() method", function() {
+                var searchBuilder = variables.model.new(
+                    variables.testIndexName,
+                    "testdocs"
+                );
+
+                searchBuilder.terms( "title", "Foo,Bar" );
+
+                expect( searchBuilder.getQuery() ).toBeStruct();
+                expect( searchBuilder.getQuery() ).toHaveKey( "terms" );
+                expect( searchBuilder.getQuery().terms ).toBe( { "title" : [ "Foo", "Bar" ] } );
+            } );
 
             it( "Tests the filterTerm() method", function() {
                 var searchBuilder = variables.model.new(

--- a/tests/specs/unit/SearchBuilderTest.cfc
+++ b/tests/specs/unit/SearchBuilderTest.cfc
@@ -376,6 +376,46 @@ component extends="coldbox.system.testing.BaseTestCase"{
 
 			});
 
+            it( "Tests the filterTerm() method", function() {
+                var searchBuilder = variables.model.new(
+                    variables.testIndexName,
+                    "testdocs"
+                );
+
+                searchBuilder.filterTerm( "title", "Foo" );
+
+                expect( searchBuilder.getQuery() ).toBeStruct();
+                expect( searchBuilder.getQuery() ).toHaveKey( "bool" );
+                expect( searchBuilder.getQuery().bool ).toHaveKey( "filter" );
+                expect( searchBuilder.getQuery().bool.filter ).toHaveKey( "bool" );
+                expect( searchBuilder.getQuery().bool.filter.bool ).toHaveKey( "must" );
+                expect( searchBuilder.getQuery().bool.filter.bool.must ).toBeArray();
+                expect( searchBuilder.getQuery().bool.filter.bool.must ).toHaveLength( 1 );
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ] ).toBeStruct();
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ] ).toHaveKey( "term" );
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ].term ).toBe( { "title" : "Foo" } );
+            } );
+
+            it( "Tests the filterTerms() method with a single argument", function() {
+                var searchBuilder = variables.model.new(
+                    variables.testIndexName,
+                    "testdocs"
+                );
+
+                searchBuilder.filterTerms( "title", "Foo" );
+
+                expect( searchBuilder.getQuery() ).toBeStruct();
+                expect( searchBuilder.getQuery() ).toHaveKey( "bool" );
+                expect( searchBuilder.getQuery().bool ).toHaveKey( "filter" );
+                expect( searchBuilder.getQuery().bool.filter ).toHaveKey( "bool" );
+                expect( searchBuilder.getQuery().bool.filter.bool ).toHaveKey( "must" );
+                expect( searchBuilder.getQuery().bool.filter.bool.must ).toBeArray();
+                expect( searchBuilder.getQuery().bool.filter.bool.must ).toHaveLength( 1 );
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ] ).toBeStruct();
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ] ).toHaveKey( "term" );
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ].term ).toBe( { "title" : "Foo" } );
+            } );
+
 
 			it( "Tests the filterTerms() method with a list", function(){
 				var searchBuilder = variables.model.new(


### PR DESCRIPTION
Passing a single argument to `filterTerms` redirects it to `term` which is a match instead of a filter.  This PR introduces a `filterTerm` and a `terms` method to fill out the match and filter context methods for term-based queries.