### PR TITLE
Fix Document@Elasticsearch injection typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,7 +360,7 @@ To retrieve an existing document, we must first know the `_id` value.  We can ei
 Using the `Document` object's accessors:
 
 ```
-var existingDocument = getInstance( "Document@Elasticsearch" )
+var existingDocument = getInstance( "Document@cbElasticsearch" )
     .setIndex( "bookshop" )
     .setTitle( "book" )
     .setId( bookId )


### PR DESCRIPTION
The readme for retrieving documents has a typo - I believe this should be `getInstance( "Document@cbElasticsearch" )`, not `getInstance( "Document@Elasticsearch" )`.