### PR TITLE
Fix doc retrieval `setTitle()` typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -362,7 +362,7 @@ Using the `Document` object's accessors:
 ```
 var existingDocument = getInstance( "Document@cbElasticsearch" )
     .setIndex( "bookshop" )
-    .setTitle( "book" )
+    .setType( "book" )
     .setId( bookId )
     .get();
 ```


### PR DESCRIPTION
This is supposed to be `setType()`, not `setTitle()`, yes?

Contrast this:

```
var existingDocument = getInstance( "Document@cbElasticsearch" )
    .get(
        id = bookId,
        index = "bookshop",
        type = "book"
    );
```

with this:

```
var existingDocument = getInstance( "Document@cbElasticsearch" )
    .setIndex( "bookshop" )
    .setTitle( "book" )
    .setId( bookId )
    .get();
```

The above throws an error because `setTitle()` doesn't exist.