### PR TITLE
Add a reindex action to client

### DIFF
--- a/modules/cbelasticsearch/models/Client.cfc
+++ b/modules/cbelasticsearch/models/Client.cfc
@@ -5,12 +5,12 @@
 * @package cbElasticsearch.models.Elasticsearch
 * @author Jon Clausen <jclausen@ortussolutions.com>
 * @license Apache v2.0 <http://www.apache.org/licenses/>
-* 
+*
 */
-component 
-	name="ElasticsearchClient" 
-	accessors="true" 
-	threadsafe 
+component
+	name="ElasticsearchClient"
+	accessors="true"
+	threadsafe
 	singleton
 {
 	property name="wirebox" inject="wirebox";
@@ -19,7 +19,7 @@ component
 	* Properties created on init()
 	*/
 	property name="nativeClient";
-	
+
 	/**
 	* Constructor
 	*/
@@ -39,7 +39,7 @@ component
 	* After init the autowire properties
 	*/
 	public function onDIComplete(){
-		
+
 		//The Elasticsearch driver client
 		variables.nativeClient = variables.wirebox.getInstance( getConfig().get( 'client' ) );
 
@@ -60,7 +60,7 @@ component
 	/**
 	* Execute a client search request
 	* @searchBuilder 	SearchBuilder 	An instance of the SearchBuilder object
-	* 
+	*
 	* @return 			iNativeClient 	An implementation of the iNativeClient
 	* @interfaced
 	**/
@@ -85,7 +85,7 @@ component
 
 	/**
 	* Verifies whether an index exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	**/
 	boolean function indexExists( required string indexName ){
@@ -95,23 +95,25 @@ component
 
 	/**
 	* Verifies whether an index mapping exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	* @mapping 			string 		the name of the mapping
 	**/
-	boolean function indexMappingExists( 
-		required string indexName, 
-		required string mapping 
+	boolean function indexMappingExists(
+		required string indexName,
+		required string mapping
 	){
 
 		return variables.nativeClient.indexMappingExists( argumentCollection=arguments );
 
-	}
+    }
+
+
 
 	/**
 	* Applies an index item ( create/update )
 	* @indexBuilder 	IndexBuilder 	An instance of the IndexBuilder object
-	* 
+	*
 	* @return 			boolean 		Boolean result as to whether the index was created
 	**/
 	boolean function applyIndex( required IndexBuilder indexBuilder ){
@@ -122,26 +124,42 @@ component
 
 	/**
 	* Deletes an index
-	* 
+	*
 	* @indexName 		string 		the name of the index to be deleted
-	* 
+	*
 	**/
 	struct function deleteIndex( required string indexName ){
-		
+
 		return variables.nativeClient.deleteIndex( argumentCollection=arguments );
 
+    }
+
+    /**
+    * Applies a reindex action
+    *
+    * @source      string   The source index name or struct of options
+    * @destination string   The destination index name or struct of options
+    *
+    * @return      struct 	Struct result of the reindex action
+	**/
+	struct function reindex(
+        required any source,
+        required any destination,
+        boolean waitForCompletion = true
+    ) {
+		return variables.nativeClient.reindex( argumentCollection = arguments );
 	}
 
 	/**
 	* Deletes an index type
-	* 
+	*
 	* @indexName 		string 		the name of the index to be deleted
 	* @type 			type 		the index typing to be deleted
-	* 
+	*
 	**/
 	boolean function deleteType( required string indexName, required string type ){
-		
-		var searchBuilder = getSearchBuilder().new(  arguments.indexName, arguments.type, { "match_all" : {} }  );	
+
+		var searchBuilder = getSearchBuilder().new(  arguments.indexName, arguments.type, { "match_all" : {} }  );
 
 		return deleteByQuery( searchBuilder );
 
@@ -154,7 +172,7 @@ component
 	* @mappingConfig 			struct 		the mapping configuration struct
 	**/
 	struct function applyMapping( required string indexName, required string mappingName, required struct mappingConfig ){
-		
+
 		return variables.nativeClient.applyMapping( argumentCollection=arguments );
 	}
 
@@ -172,17 +190,17 @@ component
 
 	/**
 	* Deletes a mapping
-	* 
+	*
 	* @indexName 		string 		the name of the index which contains the mapping
 	* @mapping 			string 		the mapping ( e.g. type ) to delete
 	* @throwOnError 	boolean	  	Whether to throw an error if the mapping could not be deleted ( default=false )
-	* 
+	*
 	* @return 			struct 		the deletion transaction response
 	**/
-	boolean function deleteMapping( 
-		required string indexName, 
-		required string mapping, 
-		boolean throwOnError=false 
+	boolean function deleteMapping(
+		required string indexName,
+		required string mapping,
+		boolean throwOnError=false
 	){
 
 		return variables.nativeClient.deleteMapping( argumentCollection=arguments );
@@ -195,15 +213,15 @@ component
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	any 		Returns a Document object if found, otherwise returns null
 	**/
-	any function get( 
+	any function get(
 		required any id,
 		string index,
 		string type
 	){
-		
+
 		return variables.nativeClient.get( argumentCollection=arguments );
 
 	}
@@ -214,20 +232,20 @@ component
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	array 		An array of Document objects
 	**/
-	array function getMultiple( 
-		required array keys, 
-		string index, 
-		string type  
+	array function getMultiple(
+		required array keys,
+		string index,
+		string type
 	){
 		return variables.nativeClient.getMultiple( argumentCollection=arguments );
 	}
 
 	/**
 	* @document 		Document@cbElasticSearch 		An instance of the elasticsearch Document object
-	* 
+	*
 	* @return 			Document@cbElasticsearch 		The saved document object
 	**/
 	Document function save( required Document document ){
@@ -247,24 +265,24 @@ component
 
 	/**
 	* Delete documents from a query
-	* 
+	*
 	* @searchBuilder 		SearchBuilder 		The assemble search builder to use for the query
-	* 
+	*
 	**/
 	boolean function deleteByQuery( required SearchBuilder searchBuilder ){
-		
+
 		return variables.nativeClient.deleteByQuery( argumentCollection=arguments );
 
 	}
 
 	/**
 	* updates documents from a query
-	* 
+	*
 	* @searchBuilder 		SearchBuilder 		The assemble search builder to use for the query
 	* @script 				struct 				script to process on the query
 	**/
 	boolean function updateByQuery( required SearchBuilder searchBuilder, required struct script  ){
-		
+
 		return variables.nativeClient.updateByQuery( argumentCollection=arguments );
 
 	}
@@ -272,7 +290,7 @@ component
 	/**
 	* Persists multiple items to the index
 	* @documents 		array 					An array of elasticsearch Document objects to persist
-	* 
+	*
 	* @return 			array					An array of results for the saved items
 	**/
 	array function saveAll( required array documents ){
@@ -286,9 +304,9 @@ component
 	* @documents 	array 		Either an array of Document objects
 	* @throwOnError 	boolean			whether to throw an error if the document cannot be deleted ( default: false )
 	**/
-	any function deleteAll( 
-		required array documents, 
-		boolean throwOnError=false 
+	any function deleteAll(
+		required array documents,
+		boolean throwOnError=false
 	){
 
 		return variables.nativeClient.deleteAll( documents );

--- a/modules/cbelasticsearch/models/iNativeClient.cfc
+++ b/modules/cbelasticsearch/models/iNativeClient.cfc
@@ -1,12 +1,12 @@
 /**
 *
 * Elasticsearch Native Client Interface
-* 
+*
 * @singleton
 * @package cbElasticsearch.models
 * @author Jon Clausen <jclausen@ortussolutions.com>
 * @license Apache v2.0 <http://www.apache.org/licenses/>
-* 
+*
 */
 interface{
 
@@ -21,7 +21,7 @@ interface{
 	/**
 	* Execute a client search request
 	* @searchBuilder 	SearchBuilder 	An instance of the SearchBuilder object
-	* 
+	*
 	* @return 			iNativeClient 	An implementation of the iNativeClient
 	* @interfaced
 	**/
@@ -38,27 +38,27 @@ interface{
 
 	/**
 	* Verifies whether an index exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	**/
 	boolean function indexExists( required string indexName );
 
 	/**
 	* Verifies whether an index mapping exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	* @mapping 			string 		the name of the mapping
 	* @interfaced
 	**/
-	boolean function indexMappingExists( 
-		required string indexName, 
-		required string mapping 
+	boolean function indexMappingExists(
+		required string indexName,
+		required string mapping
 	);
 
 	/**
 	* Applies an index item ( create/update )
 	* @indexBuilder 	IndexBuilder 	An instance of the IndexBuilder object
-	* 
+	*
 	* @return 			struct 		A struct representation of the transaction result
 	* @interfaced
 	**/
@@ -66,12 +66,26 @@ interface{
 
 	/**
 	* Deletes an index
-	* 
+	*
 	* @indexName 		string 		the name of the index to be deleted
-	* 
+	*
 	**/
 	struct function deleteIndex( required string indexName );
 
+    /**
+    * Applies a reindex action
+    * @interfaced
+    *
+    * @source      any   The source index name or struct of options
+    * @destination any   The destination index name or struct of options
+	*
+	* @return      struct 	Struct result of the reindex action
+	**/
+	struct function reindex(
+        required any source,
+        required any destination,
+        boolean waitForCompletion
+    );
 
 	/**
 	* Applies a single mapping to an index
@@ -93,11 +107,11 @@ interface{
 
 	/**
 	* Deletes a mapping
-	* 
+	*
 	* @indexName 		string 		the name of the index which contains the mapping
 	* @mapping 			string 		the mapping ( e.g. type ) to delete
 	* @throwOnError 	boolean	  	Whether to throw an error if the mapping could not be deleted ( default=false )
-	* 
+	*
 	* @return 			struct 		the deletion transaction response
 	**/
 	boolean function deleteMapping( required string indexName, required string mapping, boolean throwOnError=false );
@@ -108,10 +122,10 @@ interface{
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	any 		Returns a Document object if found, otherwise returns null
 	**/
-	any function get( 
+	any function get(
 		required any id,
 		string index,
 		string type
@@ -123,18 +137,18 @@ interface{
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	array 		An array of Document objects
 	**/
-	array function getMultiple( 
-		required array keys, 
-		string index, 
-		string type  
+	array function getMultiple(
+		required array keys,
+		string index,
+		string type
 	);
 
 	/**
 	* @document 		Document@cbElasticSearch 		An instance of the elasticsearch Document object
-	* 
+	*
 	* @return 			iNativeClient 					An implementation of the iNativeClient
 	* @interfaced
 	**/
@@ -164,7 +178,7 @@ interface{
 	/**
 	* Persists multiple items to the index
 	* @documents 		array 					An array of elasticsearch Document objects to persist
-	* 
+	*
 	* @return 			array					An array of results for the saved items
 	* @interfaced
 	**/
@@ -175,9 +189,9 @@ interface{
 	* @documents 	array 		Either an array of Document objects
 	* @throwOnError 	boolean			whether to throw an error if the document cannot be deleted ( default: false )
 	**/
-	any function deleteAll( 
-		required array documents, 
-		boolean throwOnError=false 
+	any function deleteAll(
+		required array documents,
+		boolean throwOnError=false
 	);
 
 

--- a/readme.md
+++ b/readme.md
@@ -456,6 +456,47 @@ getInstance( "SearchBuilder@cbElasticsearch" )
     .deleteAll();
 ```
 
+#### Reindexing
+
+On occassion, due to a mapping or settings change, you will need to reindex data
+from one index to another.  You can do this by calling the `reindex` method
+on the `Client`.
+
+```
+getInstance( "Client@cbElasticsearch" )
+    .reindex( "oldIndex", "newIndex" );
+```
+
+If you want the work to be done asynchronusly, you can pass `false` to the
+`waitForCompletion` flag.
+
+```
+getInstance( "Client@cbElasticsearch" )
+    .reindex(
+        source = "oldIndex",
+        destination = "newIndex"
+        waitForCompletion = false
+    );
+```
+
+If you have more settings or constriants for the reindex action, you can pass
+a struct containing valid options to `source` and `destination`.
+
+```
+getInstance( "Client@cbElasticsearch" )
+    .reindex(
+        source = {
+            "index": "oldIndex",
+            "type": "testdocs",
+            "query": {
+                "term": {
+                    "active": true
+                }
+            }
+        },
+        destination = "newIndex"
+    );
+```
 
 Searching Documents
 ===================
@@ -528,7 +569,7 @@ In the above example, documents with a `name` field containing "Elasticsearch" w
 
 #### Advanced Query DSL
 
-The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing detailed configuration of queries, if the basic `match()`, `sort()` and `aggregate()` methods are not enough to meet your needs. There are several methods to provide the raw query language to the Search Builder.  One is during instantiation.  
+The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing detailed configuration of queries, if the basic `match()`, `sort()` and `aggregate()` methods are not enough to meet your needs. There are several methods to provide the raw query language to the Search Builder.  One is during instantiation.
 
 In the following we are looking for matches of active records with "Elasticsearch" in the `name`, `description`, or `shortDescription` fields. We are also looking for a phrase match of "is awesome" and are boosting the score of the applicable document, if found.
 

--- a/tests/specs/unit/ClientTest.cfc
+++ b/tests/specs/unit/ClientTest.cfc
@@ -1,5 +1,5 @@
 component extends="JestClientTest"{
-	
+
 	function beforeAll(){
 		this.loadColdbox=true;
 
@@ -7,9 +7,12 @@ component extends="JestClientTest"{
 
 		variables.model = getWirebox().getInstance( "Client@cbElasticsearch" );
 		variables.testIndexName = lcase( "ElasticsearchClientTests" );
+		variables.testIndexNameOne = lcase( "ElasticsearchClientTestsOne" );
+		variables.testIndexNameTwo = lcase( "ElasticsearchClientTestsTwo" );
 
 		variables.model.deleteIndex( variables.testIndexName );
-
+		variables.model.deleteIndex( variables.testIndexNameOne );
+		variables.model.deleteIndex( variables.testIndexNameTwo );
 	}
 
 	function run(){
@@ -24,8 +27,8 @@ component extends="JestClientTest"{
 				var documents = [];
 
 				for( var i=1; i <= 13; i++ ){
-					arrayAppend( 
-						documents, getInstance( "Document@cbElasticsearch" ).new(  
+					arrayAppend(
+						documents, getInstance( "Document@cbElasticsearch" ).new(
 							variables.testIndexName,
 							"testdocs",
 							{
@@ -34,12 +37,12 @@ component extends="JestClientTest"{
 								"createdTime": dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" )
 							}
 						)
-						
+
 					);
 				}
 
 				var savedDocs = variables.model.saveAll( documents );
-				
+
 				//sleep for 1.5 seconds to ensure full persistence
 				sleep( 1500 );
 
@@ -47,8 +50,132 @@ component extends="JestClientTest"{
 
 				expect( deleted ).toBeTrue();
 
-			});
+            });
 
+            describe( "reindex", function() {
+                it( "can reindex from one index to another", function() {
+                    getWireBox().getInstance( "IndexBuilder@cbElasticSearch" )
+                        .new( variables.testIndexNameTwo )
+                        .save();
+
+                    //insert some documents to reindex
+                    var documents = [];
+
+                    for ( var i = 1; i <= 13; i++ ) {
+                        arrayAppend(
+                            documents, getInstance( "Document@cbElasticsearch" ).new(
+                                variables.testIndexNameOne,
+                                "testdocs",
+                                {
+                                    "_id": createUUID(),
+                                    "title": "Test Document Number #i#",
+                                    "createdTime": dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" )
+                                }
+                            )
+
+                        );
+                    }
+
+                    var savedDocs = variables.model.saveAll( documents );
+
+                    //sleep for 1.5 seconds to ensure full persistence
+                    sleep( 1500 );
+
+                    var searchOne = getWireBox().getInstance( "SearchBuilder@cbElasticSearch" )
+                        .new( variables.testIndexNameOne, "testdocs", {
+                            "query": {
+                                "match_all": {}
+                            }
+                        } );
+
+                    var searchTwo = getWireBox().getInstance( "SearchBuilder@cbElasticSearch" )
+                        .new( variables.testIndexNameTwo, "testdocs", {
+                            "query": {
+                                "match_all": {}
+                            }
+                        } );
+
+                    expect( variables.model.count( searchTwo ) )
+                        .toBe( 0, "No documents should exists in the second index" );
+
+                    variables.model.reindex(
+                        source = variables.testIndexNameOne,
+                        destination = variables.testIndexNameTwo
+                    );
+
+                    sleep( 1500 );
+
+                    expect( variables.model.count( searchTwo ) )
+                        .toBe( variables.model.count( searchOne ), "All the documents from the first index should exist in the second index" );
+                } );
+
+                it( "can pass structs for the source and destination", function() {
+                    variables.model.deleteIndex( variables.testIndexNameOne );
+		            variables.model.deleteIndex( variables.testIndexNameTwo );
+
+                    getWireBox().getInstance( "IndexBuilder@cbElasticSearch" )
+                        .new( variables.testIndexNameTwo )
+                        .save();
+
+                    // //insert some documents to reindex
+                    var documents = [];
+
+                    for ( var i = 1; i <= 10; i++ ) {
+                        arrayAppend(
+                            documents, getInstance( "Document@cbElasticsearch" ).new(
+                                variables.testIndexNameOne,
+                                "testdocs",
+                                {
+                                    "_id": createUUID(),
+                                    "title": "Test Document Number #i#",
+                                    "flag": i % 2 == 0 ? "flag" : "noflag",
+                                    "createdTime": dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" )
+                                }
+                            )
+
+                        );
+                    }
+
+                    var savedDocs = variables.model.saveAll( documents );
+
+                    //sleep for 1.5 seconds to ensure full persistence
+                    sleep( 1500 );
+
+                    var searchOne = getWireBox().getInstance( "SearchBuilder@cbElasticSearch" )
+                        .new( variables.testIndexNameOne, "testdocs", {
+                            "query": {
+                                "match_all": {}
+                            }
+                        } );
+
+                    var searchTwo = getWireBox().getInstance( "SearchBuilder@cbElasticSearch" )
+                        .new( variables.testIndexNameTwo, "testdocs", {
+                            "query": {
+                                "match_all": {}
+                            }
+                        } );
+
+                    expect( variables.model.count( searchOne ) ).toBe( 10 );
+                    expect( variables.model.count( searchTwo ) ).toBe( 0 );
+
+                    variables.model.reindex(
+                        source = {
+                            "index": variables.testIndexNameOne,
+                            "type": "testdocs",
+                            "query": {
+                                "term": {
+                                    "flag.keyword": "flag"
+                                }
+                            }
+                        },
+                        destination = variables.testIndexNameTwo
+                    );
+
+                    sleep( 1500 );
+
+                    expect( variables.model.count( searchTwo ) ).toBe( 5 );
+                } );
+            } );
 		});
 	}
 


### PR DESCRIPTION
This PR lets you reindex from index to another. You can do this by calling the `reindex` method
on the `Client`.

```
getInstance( "Client@cbElasticsearch" )
    .reindex( "oldIndex", "newIndex" );
```

If you want the work to be done asynchronusly, you can pass `false` to the
`waitForCompletion` flag.

```
getInstance( "Client@cbElasticsearch" )
    .reindex(
        source = "oldIndex",
        destination = "newIndex"
        waitForCompletion = false
    );
```

If you have more settings or constriants for the reindex action, you can pass
a struct containing valid options to `source` and `destination`.

```
getInstance( "Client@cbElasticsearch" )
    .reindex(
        source = {
            "index": "oldIndex",
            "type": "testdocs",
            "query": {
                "term": {
                    "active": true
                }
            }
        },
        destination = "newIndex"
    );
```