### PR TITLE
Add or remove aliases in bulk

### DIFF
--- a/modules/cbelasticsearch/models/AliasBuilder.cfc
+++ b/modules/cbelasticsearch/models/AliasBuilder.cfc
@@ -1,0 +1,28 @@
+component accessors="true" {
+
+    property name="type";
+    property name="indexName";
+    property name="aliasName";
+
+    function add( required string indexName, required string aliasName ) {
+        arguments.type = "add";
+        return new( argumentCollection = arguments );
+    }
+
+    function remove( required string indexName, required string aliasName ) {
+        arguments.type = "remove";
+        return new( argumentCollection = arguments );
+    }
+
+    function new(
+        required string type,
+        required string indexName,
+        required string aliasName
+    ) {
+        setType( arguments.type );
+        setIndexName( arguments.indexName );
+        setAliasName( arguments.aliasName );
+        return this;
+    }
+
+}

--- a/modules/cbelasticsearch/models/AliasBuilder.cfc
+++ b/modules/cbelasticsearch/models/AliasBuilder.cfc
@@ -1,25 +1,25 @@
 component accessors="true" {
 
-    property name="type";
+    property name="action";
     property name="indexName";
     property name="aliasName";
 
     function add( required string indexName, required string aliasName ) {
-        arguments.type = "add";
+        arguments.action = "add";
         return new( argumentCollection = arguments );
     }
 
     function remove( required string indexName, required string aliasName ) {
-        arguments.type = "remove";
+        arguments.action = "remove";
         return new( argumentCollection = arguments );
     }
 
     function new(
-        required string type,
+        required string action,
         required string indexName,
         required string aliasName
     ) {
-        setType( arguments.type );
+        setAction( arguments.action );
         setIndexName( arguments.indexName );
         setAliasName( arguments.aliasName );
         return this;

--- a/modules/cbelasticsearch/models/Client.cfc
+++ b/modules/cbelasticsearch/models/Client.cfc
@@ -5,12 +5,12 @@
 * @package cbElasticsearch.models.Elasticsearch
 * @author Jon Clausen <jclausen@ortussolutions.com>
 * @license Apache v2.0 <http://www.apache.org/licenses/>
-* 
+*
 */
-component 
-	name="ElasticsearchClient" 
-	accessors="true" 
-	threadsafe 
+component
+	name="ElasticsearchClient"
+	accessors="true"
+	threadsafe
 	singleton
 {
 	property name="wirebox" inject="wirebox";
@@ -19,7 +19,7 @@ component
 	* Properties created on init()
 	*/
 	property name="nativeClient";
-	
+
 	/**
 	* Constructor
 	*/
@@ -39,7 +39,7 @@ component
 	* After init the autowire properties
 	*/
 	public function onDIComplete(){
-		
+
 		//The Elasticsearch driver client
 		variables.nativeClient = variables.wirebox.getInstance( getConfig().get( 'client' ) );
 
@@ -60,7 +60,7 @@ component
 	/**
 	* Execute a client search request
 	* @searchBuilder 	SearchBuilder 	An instance of the SearchBuilder object
-	* 
+	*
 	* @return 			iNativeClient 	An implementation of the iNativeClient
 	* @interfaced
 	**/
@@ -85,7 +85,7 @@ component
 
 	/**
 	* Verifies whether an index exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	**/
 	boolean function indexExists( required string indexName ){
@@ -95,13 +95,13 @@ component
 
 	/**
 	* Verifies whether an index mapping exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	* @mapping 			string 		the name of the mapping
 	**/
-	boolean function indexMappingExists( 
-		required string indexName, 
-		required string mapping 
+	boolean function indexMappingExists(
+		required string indexName,
+		required string mapping
 	){
 
 		return variables.nativeClient.indexMappingExists( argumentCollection=arguments );
@@ -111,7 +111,7 @@ component
 	/**
 	* Applies an index item ( create/update )
 	* @indexBuilder 	IndexBuilder 	An instance of the IndexBuilder object
-	* 
+	*
 	* @return 			boolean 		Boolean result as to whether the index was created
 	**/
 	boolean function applyIndex( required IndexBuilder indexBuilder ){
@@ -122,29 +122,40 @@ component
 
 	/**
 	* Deletes an index
-	* 
+	*
 	* @indexName 		string 		the name of the index to be deleted
-	* 
+	*
 	**/
 	struct function deleteIndex( required string indexName ){
-		
+
 		return variables.nativeClient.deleteIndex( argumentCollection=arguments );
 
 	}
 
 	/**
 	* Deletes an index type
-	* 
+	*
 	* @indexName 		string 		the name of the index to be deleted
 	* @type 			type 		the index typing to be deleted
-	* 
+	*
 	**/
 	boolean function deleteType( required string indexName, required string type ){
-		
-		var searchBuilder = getSearchBuilder().new(  arguments.indexName, arguments.type, { "match_all" : {} }  );	
+
+		var searchBuilder = getSearchBuilder().new(  arguments.indexName, arguments.type, { "match_all" : {} }  );
 
 		return deleteByQuery( searchBuilder );
 
+    }
+
+    /**
+    * Applies an alias (or array of aliases)
+    *
+	* @aliases    AliasBuilder    An AliasBuilder instance (or array of instances)
+	*
+	* @return     boolean 		  Boolean result as to whether the operations were successful
+	**/
+	boolean function applyAliases( required any aliases ) {
+		return variables.nativeClient.applyAliases( argumentCollection=arguments );
 	}
 
 	/**
@@ -154,7 +165,7 @@ component
 	* @mappingConfig 			struct 		the mapping configuration struct
 	**/
 	struct function applyMapping( required string indexName, required string mappingName, required struct mappingConfig ){
-		
+
 		return variables.nativeClient.applyMapping( argumentCollection=arguments );
 	}
 
@@ -172,17 +183,17 @@ component
 
 	/**
 	* Deletes a mapping
-	* 
+	*
 	* @indexName 		string 		the name of the index which contains the mapping
 	* @mapping 			string 		the mapping ( e.g. type ) to delete
 	* @throwOnError 	boolean	  	Whether to throw an error if the mapping could not be deleted ( default=false )
-	* 
+	*
 	* @return 			struct 		the deletion transaction response
 	**/
-	boolean function deleteMapping( 
-		required string indexName, 
-		required string mapping, 
-		boolean throwOnError=false 
+	boolean function deleteMapping(
+		required string indexName,
+		required string mapping,
+		boolean throwOnError=false
 	){
 
 		return variables.nativeClient.deleteMapping( argumentCollection=arguments );
@@ -195,15 +206,15 @@ component
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	any 		Returns a Document object if found, otherwise returns null
 	**/
-	any function get( 
+	any function get(
 		required any id,
 		string index,
 		string type
 	){
-		
+
 		return variables.nativeClient.get( argumentCollection=arguments );
 
 	}
@@ -214,20 +225,20 @@ component
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	array 		An array of Document objects
 	**/
-	array function getMultiple( 
-		required array keys, 
-		string index, 
-		string type  
+	array function getMultiple(
+		required array keys,
+		string index,
+		string type
 	){
 		return variables.nativeClient.getMultiple( argumentCollection=arguments );
 	}
 
 	/**
 	* @document 		Document@cbElasticSearch 		An instance of the elasticsearch Document object
-	* 
+	*
 	* @return 			Document@cbElasticsearch 		The saved document object
 	**/
 	Document function save( required Document document ){
@@ -247,24 +258,24 @@ component
 
 	/**
 	* Delete documents from a query
-	* 
+	*
 	* @searchBuilder 		SearchBuilder 		The assemble search builder to use for the query
-	* 
+	*
 	**/
 	boolean function deleteByQuery( required SearchBuilder searchBuilder ){
-		
+
 		return variables.nativeClient.deleteByQuery( argumentCollection=arguments );
 
 	}
 
 	/**
 	* updates documents from a query
-	* 
+	*
 	* @searchBuilder 		SearchBuilder 		The assemble search builder to use for the query
 	* @script 				struct 				script to process on the query
 	**/
 	boolean function updateByQuery( required SearchBuilder searchBuilder, required struct script  ){
-		
+
 		return variables.nativeClient.updateByQuery( argumentCollection=arguments );
 
 	}
@@ -272,7 +283,7 @@ component
 	/**
 	* Persists multiple items to the index
 	* @documents 		array 					An array of elasticsearch Document objects to persist
-	* 
+	*
 	* @return 			array					An array of results for the saved items
 	**/
 	array function saveAll( required array documents ){
@@ -286,9 +297,9 @@ component
 	* @documents 	array 		Either an array of Document objects
 	* @throwOnError 	boolean			whether to throw an error if the document cannot be deleted ( default: false )
 	**/
-	any function deleteAll( 
-		required array documents, 
-		boolean throwOnError=false 
+	any function deleteAll(
+		required array documents,
+		boolean throwOnError=false
 	){
 
 		return variables.nativeClient.deleteAll( documents );

--- a/modules/cbelasticsearch/models/JestClient.cfc
+++ b/modules/cbelasticsearch/models/JestClient.cfc
@@ -298,7 +298,7 @@ component
         var modifyAliasesBuilder = "";
         for ( var alias in arguments.aliases ) {
             var aliasBuilder = "";
-            switch( alias.getType() ) {
+            switch( alias.getAction() ) {
                 case "add":
                     aliasBuilder = variables.jLoader
                         .create( "io.searchbox.indices.aliases.AddAliasMapping$Builder" )
@@ -312,7 +312,7 @@ component
                         .build();
                     break;
                 default:
-                    throw( "Unsupported alias type.  Allowed types are: add, remove" );
+                    throw( "Unsupported alias action.  Allowed actions are: add, remove" );
             }
 
             if ( isSimpleValue( modifyAliasesBuilder ) ) {
@@ -324,7 +324,7 @@ component
             }
         }
 
-        return !! execute( modifyAliasesBuilder.build() ).acknowledged;
+        return execute( modifyAliasesBuilder.build() ).acknowledged;
 	}
 
 

--- a/modules/cbelasticsearch/models/JestClient.cfc
+++ b/modules/cbelasticsearch/models/JestClient.cfc
@@ -284,6 +284,47 @@ component
 		var deleteBuilder = variables.jLoader.create( "io.searchbox.indices.DeleteIndex$Builder" ).init( arguments.indexName );
 
 		return execute( deleteBuilder.build() );
+    }
+
+    /**
+    * Applies an alias (or array of aliases)
+    *
+	* @aliases    AliasBuilder    An AliasBuilder instance (or array of instances)
+	*
+	* @return     boolean 		  Boolean result as to whether the operations were successful
+	**/
+	boolean function applyAliases( required any aliases ) {
+        arguments.aliases = isArray( arguments.aliases ) ? arguments.aliases : [ arguments.aliases ];
+        var modifyAliasesBuilder = "";
+        for ( var alias in arguments.aliases ) {
+            var aliasBuilder = "";
+            switch( alias.getType() ) {
+                case "add":
+                    aliasBuilder = variables.jLoader
+                        .create( "io.searchbox.indices.aliases.AddAliasMapping$Builder" )
+                        .init( alias.getIndexName(), alias.getAliasName() )
+                        .build();
+                    break;
+                case "remove":
+                    aliasBuilder = variables.jLoader
+                        .create( "io.searchbox.indices.aliases.RemoveAliasMapping$Builder" )
+                        .init( alias.getIndexName(), alias.getAliasName() )
+                        .build();
+                    break;
+                default:
+                    throw( "Unsupported alias type.  Allowed types are: add, remove" );
+            }
+
+            if ( isSimpleValue( modifyAliasesBuilder ) ) {
+                modifyAliasesBuilder = variables.jLoader
+                    .create( "io.searchbox.indices.aliases.ModifyAliases$Builder" )
+                    .init( aliasBuilder );
+            } else {
+                modifyAliasesBuilder.addAlias( aliasBuilder );
+            }
+        }
+
+        return !! execute( modifyAliasesBuilder.build() ).acknowledged;
 	}
 
 

--- a/modules/cbelasticsearch/models/iNativeClient.cfc
+++ b/modules/cbelasticsearch/models/iNativeClient.cfc
@@ -1,12 +1,12 @@
 /**
 *
 * Elasticsearch Native Client Interface
-* 
+*
 * @singleton
 * @package cbElasticsearch.models
 * @author Jon Clausen <jclausen@ortussolutions.com>
 * @license Apache v2.0 <http://www.apache.org/licenses/>
-* 
+*
 */
 interface{
 
@@ -21,7 +21,7 @@ interface{
 	/**
 	* Execute a client search request
 	* @searchBuilder 	SearchBuilder 	An instance of the SearchBuilder object
-	* 
+	*
 	* @return 			iNativeClient 	An implementation of the iNativeClient
 	* @interfaced
 	**/
@@ -38,27 +38,27 @@ interface{
 
 	/**
 	* Verifies whether an index exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	**/
 	boolean function indexExists( required string indexName );
 
 	/**
 	* Verifies whether an index mapping exists
-	* 
+	*
 	* @indexName 		string 		the name of the index
 	* @mapping 			string 		the name of the mapping
 	* @interfaced
 	**/
-	boolean function indexMappingExists( 
-		required string indexName, 
-		required string mapping 
+	boolean function indexMappingExists(
+		required string indexName,
+		required string mapping
 	);
 
 	/**
 	* Applies an index item ( create/update )
 	* @indexBuilder 	IndexBuilder 	An instance of the IndexBuilder object
-	* 
+	*
 	* @return 			struct 		A struct representation of the transaction result
 	* @interfaced
 	**/
@@ -66,11 +66,20 @@ interface{
 
 	/**
 	* Deletes an index
-	* 
+	*
 	* @indexName 		string 		the name of the index to be deleted
-	* 
+	*
 	**/
-	struct function deleteIndex( required string indexName );
+    struct function deleteIndex( required string indexName );
+
+    /**
+    * Applies an alias (or array of aliases)
+    *
+	* @aliases    AliasBuilder    An AliasBuilder instance (or array of instances)
+	*
+	* @return     boolean 		  Boolean result as to whether the operations were successful
+	**/
+	boolean function applyAliases( required any aliases );
 
 
 	/**
@@ -93,11 +102,11 @@ interface{
 
 	/**
 	* Deletes a mapping
-	* 
+	*
 	* @indexName 		string 		the name of the index which contains the mapping
 	* @mapping 			string 		the mapping ( e.g. type ) to delete
 	* @throwOnError 	boolean	  	Whether to throw an error if the mapping could not be deleted ( default=false )
-	* 
+	*
 	* @return 			struct 		the deletion transaction response
 	**/
 	boolean function deleteMapping( required string indexName, required string mapping, boolean throwOnError=false );
@@ -108,10 +117,10 @@ interface{
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	any 		Returns a Document object if found, otherwise returns null
 	**/
-	any function get( 
+	any function get(
 		required any id,
 		string index,
 		string type
@@ -123,18 +132,18 @@ interface{
 	* @index 	string 		The name of the index
 	* @type 	type 		The name of the type
 	* @interfaced
-	* 
+	*
 	* @return 	array 		An array of Document objects
 	**/
-	array function getMultiple( 
-		required array keys, 
-		string index, 
-		string type  
+	array function getMultiple(
+		required array keys,
+		string index,
+		string type
 	);
 
 	/**
 	* @document 		Document@cbElasticSearch 		An instance of the elasticsearch Document object
-	* 
+	*
 	* @return 			iNativeClient 					An implementation of the iNativeClient
 	* @interfaced
 	**/
@@ -164,7 +173,7 @@ interface{
 	/**
 	* Persists multiple items to the index
 	* @documents 		array 					An array of elasticsearch Document objects to persist
-	* 
+	*
 	* @return 			array					An array of results for the saved items
 	* @interfaced
 	**/
@@ -175,9 +184,9 @@ interface{
 	* @documents 	array 		Either an array of Document objects
 	* @throwOnError 	boolean			whether to throw an error if the document cannot be deleted ( default: false )
 	**/
-	any function deleteAll( 
-		required array documents, 
-		boolean throwOnError=false 
+	any function deleteAll(
+		required array documents,
+		boolean throwOnError=false
 	);
 
 

--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,26 @@ indexBuilder.new(
 * [Index Settings Reference](https://www.elastic.co/guide/en/elasticsearch/guide/current/_index_settings.html)
 
 
+## Alias Builder
+
+cbElasticSearch can add or remove aliases in bulk using the `applyAliases` method
+on the cbElasticSearch client.
+
+```
+var removeAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+    .remove( indexName = "testIndexName", aliasName = "aliasNameOne" );
+var addNewAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+    .add( indexName = "testIndexName", aliasName = "aliasNameTwo" );
+
+variables.client.applyAliases(
+    // a single alias action can also be provided
+    aliases = [ removeAliasAction, addNewAliasAction ]
+);
+```
+
+These operations will be done in the same transaction, so it's safe to use for
+switching the alias from one index to another.
+
 
 ## Mapping Builder
 
@@ -528,7 +548,7 @@ In the above example, documents with a `name` field containing "Elasticsearch" w
 
 #### Advanced Query DSL
 
-The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing detailed configuration of queries, if the basic `match()`, `sort()` and `aggregate()` methods are not enough to meet your needs. There are several methods to provide the raw query language to the Search Builder.  One is during instantiation.  
+The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing detailed configuration of queries, if the basic `match()`, `sort()` and `aggregate()` methods are not enough to meet your needs. There are several methods to provide the raw query language to the Search Builder.  One is during instantiation.
 
 In the following we are looking for matches of active records with "Elasticsearch" in the `name`, `description`, or `shortDescription` fields. We are also looking for a phrase match of "is awesome" and are boosting the score of the applicable document, if found.
 

--- a/tests/specs/unit/AliasBuilderTest.cfc
+++ b/tests/specs/unit/AliasBuilderTest.cfc
@@ -1,0 +1,91 @@
+component extends="coldbox.system.testing.BaseTestCase"{
+
+	function beforeAll(){
+		this.loadColdbox = true;
+
+        setup();
+
+        variables.client = getWireBox().getInstance( "Client@cbElasticSearch" );
+		variables.testIndexName = lcase( "AliasBuilderTests" );
+		variables.client.deleteIndex( variables.testIndexName );
+	}
+
+	function run() {
+		describe( "aliases", function() {
+            beforeEach( function() {
+                variables.client.deleteIndex( variables.testIndexName );
+                // create an index
+                getWireBox().getInstance( "IndexBuilder@cbElasticSearch" )
+                    .new( variables.testIndexName )
+                    .save();
+            } );
+
+            it( "can add an alias", function() {
+                // create an alias
+                var aliasName = lcase( "AliasBuilderTestsAlias" );
+
+                var addAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+                    .add( indexName = variables.testIndexName, aliasName = aliasName );
+
+                variables.client.applyAliases(
+                    aliases = addAliasAction
+                );
+
+                // verify the alias as an index
+                expect( variables.client.indexExists( aliasName ) ).toBeTrue();
+            } );
+
+            it( "can remove an alias", function() {
+                // create an alias
+                var aliasName = lcase( "AliasBuilderTestsAlias" );
+
+                var addAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+                    .add( indexName = variables.testIndexName, aliasName = aliasName );
+
+                variables.client.applyAliases(
+                    aliases = addAliasAction
+                );
+
+                // now remove the alias
+                var removeAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+                    .remove( indexName = variables.testIndexName, aliasName = aliasName );
+
+                variables.client.applyAliases(
+                    aliases = removeAliasAction
+                );
+
+                // verify the alias as an index
+                expect( variables.client.indexExists( aliasName ) ).toBeFalse();
+            } );
+
+            it( "can add and remove an alias at the same time", function() {
+                // create an alias
+                var aliasNameOne = lcase( "AliasBuilderTestsAliasOne" );
+
+                var addAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+                    .add( indexName = variables.testIndexName, aliasName = aliasNameOne );
+
+                variables.client.applyAliases(
+                    aliases = addAliasAction
+                );
+
+                // now remove the first alias and add the second alias
+                var aliasNameTwo = lcase( "AliasBuilderTestsAliasTwo" );
+
+                var removeAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+                    .remove( indexName = variables.testIndexName, aliasName = aliasNameOne );
+                var addNewAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
+                    .add( indexName = variables.testIndexName, aliasName = aliasNameTwo );
+
+                variables.client.applyAliases(
+                    aliases = [ removeAliasAction, addNewAliasAction ]
+                );
+
+                // verify the alias as an index
+                expect( variables.client.indexExists( aliasNameOne) ).toBeFalse();
+                expect( variables.client.indexExists( aliasNameTwo ) ).toBeTrue();
+            } );
+		} );
+	}
+
+}


### PR DESCRIPTION
cbElasticSearch can add or remove aliases in bulk using the `applyAliases` method
on the cbElasticSearch client.

```
var removeAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
    .remove( indexName = "testIndexName", aliasName = "aliasNameOne" );
var addNewAliasAction = getWireBox().getInstance( "AliasBuilder@cbElasticSearch" )
    .add( indexName = "testIndexName", aliasName = "aliasNameTwo" );

variables.client.applyAliases(
    // a single alias action can also be provided
    aliases = [ removeAliasAction, addNewAliasAction ]
);
```

These operations will be done in the same transaction, so it's safe to use for
switching the alias from one index to another.