### PR TITLE
Update Readme to remove ES7 non-support notice

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,13 +28,10 @@ Requirements
 ============
 
 * Coldbox >= v4.5
-* Elasticsearch  >= v5.0 and < v7.0
+* Elasticsearch  >= v5.0
 * Lucee >= v4.5 or Adobe Coldfusion >= v11
 
 _Note:  Most of the REST-based methods will work on Elasticsearch versions older than v5.0.  A notable exception is the multi-delete methods, which use the [delete by query](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-delete-by-query.html) functionality of ES5.  As such, Cachebox and Logbox functionality would be limited._
-
-_Note:  Elasticsearch 7.0+ is not currently supported due to the bundled [Jest client](https://github.com/searchbox-io/Jest/issues/644), specifically because of changes to [type handling in Elasticsearch 7.0](https://github.com/searchbox-io/Jest/issues/641)._
-
 
 Documentation
 =============


### PR DESCRIPTION
cbElasticSearch now supports ES7+, whoop whoop!