### PR TITLE
Ignore apidocs/ and docs/ folders in production installs - Fixes #55

### DIFF
--- a/modules/cbelasticsearch/box.json
+++ b/modules/cbelasticsearch/box.json
@@ -21,6 +21,8 @@
     },
     "ignore":[
         "**/.*",
+        "apidocs",
+        "docs",
         "tests",
         "*/.md"
     ]


### PR DESCRIPTION
This is a silly, simple fix for a silly, simple problem - there's no need to clone docs into production!

I'd like to drop these from development installations also, but I'm not sure if there's an easy way to do that without totally removing them from the repo.