### PR TITLE
Add filterMatch() searchbuilder method

### DIFF
--- a/modules/cbelasticsearch/models/SearchBuilder.cfc
+++ b/modules/cbelasticsearch/models/SearchBuilder.cfc
@@ -320,6 +320,34 @@ component accessors="true" {
 
     }
 
+    /**
+    * Adds a fuzzy value restriction ( elasticsearch: match ) and ignore relevance scoring
+    *
+    * @name 		string 		the name of the key to search
+    * @value 		string 		the value of the key
+    **/
+    SearchBuilder function filterMatch( required string name, required any value ) {
+        param variables.query.bool = {};
+        param variables.query.bool.filter = {};
+        param variables.query.bool.filter.bool = {};
+        param variables.query.bool.filter.bool.must = [];
+        variables.query.bool.filter.bool.must.append(
+            {
+                "match": {
+                    "#name#": value
+                }
+            }
+        );
+
+        return this;
+    }
+
+    /**
+    * Adds an exact value restriction ( elasticsearch: term ) and ignore relevance scoring
+    *
+    * @name 		string 		the name of the key to search
+    * @value 		string 		the value of the key
+    **/
     SearchBuilder function filterTerm( required string name, required any value ) {
         param variables.query.bool = {};
         param variables.query.bool.filter = {};

--- a/tests/specs/unit/SearchBuilderTest.cfc
+++ b/tests/specs/unit/SearchBuilderTest.cfc
@@ -530,6 +530,28 @@ component extends="coldbox.system.testing.BaseTestCase"{
 				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
             } );
 
+            it( "Tests the filterMatch() method", function() {
+                var searchBuilder = variables.model.new(
+                    variables.testIndexName,
+                    "testdocs"
+                );
+
+                searchBuilder.filterMatch( "description", "Star" );
+
+                expect( searchBuilder.getQuery() ).toBeStruct();
+                expect( searchBuilder.getQuery() ).toHaveKey( "bool" );
+                expect( searchBuilder.getQuery().bool ).toHaveKey( "filter" );
+                expect( searchBuilder.getQuery().bool.filter ).toHaveKey( "bool" );
+                expect( searchBuilder.getQuery().bool.filter.bool ).toHaveKey( "must" );
+                expect( searchBuilder.getQuery().bool.filter.bool.must ).toBeArray();
+                expect( searchBuilder.getQuery().bool.filter.bool.must ).toHaveLength( 1 );
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ] ).toBeStruct();
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ] ).toHaveKey( "match" );
+                expect( searchBuilder.getQuery().bool.filter.bool.must[ 1 ].match ).toBe( { "description" : "Star" } );
+
+				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
+            } );
+
             it( "Tests the filterTerms() method with a single argument", function() {
                 var searchBuilder = variables.model.new(
                     variables.testIndexName,


### PR DESCRIPTION
Allow devs to easily add a "match" boolean filter restriction, without building structs manually.