### PR TITLE
Remove duplicate INSTALLATION section from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,6 @@ Instructions
 
 The elasticsearch module for the Coldbox Platform provides you with a fluent search interface for Elasticsearch, in addition to a CacheBox Cache provider and a Logbox Appender.  Both the cache provider and logbox appender rely on Wirebox DSL mappings to the Elasticsearch client.  As such additional Wirebox configuration is necessary to use them outside of the Coldbox context.
 
-Installation
-============
-
-Via CommandBox:  `install cbelasticsearch`
-
 
 Requirements
 ============


### PR DESCRIPTION
Derp - the Readme must have gotten a little borked during either a merge conflict or possibly the removal of all the docs. This commit removes the redundant/duplicate INSTALLATION section so it doesn't look so dorky. :D