### PR TITLE
Strip whitespace from reindex and updateByQuery scripts

### DIFF
--- a/modules/cbelasticsearch/models/JestClient.cfc
+++ b/modules/cbelasticsearch/models/JestClient.cfc
@@ -415,7 +415,7 @@ component
 
 		if( structKeyExists( arguments, "script" ) ){
 			if( isSimpleValue( arguments.script ) ){
-				reindexBuilder.script( { "lang" : "painless", "source" : arguments.script } );
+				reindexBuilder.script( { "lang" : "painless", "source" : reReplace(arguments.script,"\n|\r|\t","","ALL") } );
 			} else {
 				reindexBuilder.script( arguments.script );
 			}
@@ -963,12 +963,18 @@ component
 		var updateBuilder = variables.jLoader
 										.create( "io.searchbox.core.UpdateByQuery$Builder" )
 										.init(
-											serializeJSON( {
-												"query" : arguments.searchBuilder.getQuery(),
-												"script": arguments.script
-											},
-											false,
-											listFindNoCase( "Lucee", server.coldfusion.productname ) ? "utf-8" : false )
+											reReplace(
+												serializeJSON(
+													{
+														"query" : arguments.searchBuilder.getQuery(),
+														"script": arguments.script
+													},
+													false,
+													listFindNoCase( "Lucee", server.coldfusion.productname )
+													? "utf-8" : false
+												),
+												"\n|\r|\t","","ALL"
+											)
 										);
 
 		updateBuilder.addIndex( arguments.searchBuilder.getIndex() );


### PR DESCRIPTION
This is a somewhat no-brainer - stripping whitespace avoids whitespace
errors from Elasticsearch and makes it a litle easier on the user (i.e.
the developer).

With that said, this is not a golden egg. In the `reindex()` method,
only the string-ified version is whitespace-stripped. (I didn't know
enough about the incoming `script` argument data format to say whether
we could manipulate this as well.)