### PR TITLE
Update documentation for module configuration

### DIFF
--- a/modules/cbelasticsearch/docs/Configuration.md
+++ b/modules/cbelasticsearch/docs/Configuration.md
@@ -51,6 +51,33 @@ moduleSettings = {
 
 At the current time only the REST-based [Hyper] native client is available. Support is in development for a socket based-client.  For most applications, however the REST-based native client will be a good fit.
 
+## Configuration via Environment Variables
+
+Since the default settings will read from environment variables if they exist, we can easily configure cbElasticsearch from a `.env` file:
+
+```bash
+# .env
+
+# Configure elasticsearch connection
+ELASTICSEARCH_HOST=localhost
+ELASTICSEARCH_PORT=9222
+ELASTICSEARCH_PASSWORD=B0xify_3v3ryth1ng
+
+# Configure data storage and retrieval
+ELASTICSEARCH_INDEX=books
+ELASTICSEARCH_SHARDS=5
+ELASTICSEARCH_REPLICAS=0
+ELASTICSEARCH_MAX_CONNECTIONS=100
+ELASTICSEARCH_READ_TIMEOUT=3000
+ELASTICSEARCH_CONNECT_TIMEOUT=3000
+```
+
+You will need to read these settings into the coldfusion server upon server start via `commandbox-dotenv` or some other method.
+
+{% hint style="warning" %}
+For security reasons, make sure to add `.env` to your `.gitignore` file to avoid committing environment secrets to github/your git server.
+{% endhint %}
+
 ## Connection to secondary Elasticsearch Clusters
 
 As of the current version, the module conventions only allow for a default connection to one cluster.  Multi-cluster native configuration is planned for a future major release, as it will be a breaking change.  You may, however, create a separate instance of the client to connect to a different cluster.  Since this needs to be accomplished after the module is loaded, the easiest way to do this is to create an application-specific module which is dedicated to connecting to that cluster.  A major caveat, at this time, however is that native CRUD methods in the `Document`, `SearchBuilder`, `IndexBuilder`, and `ElasticsearchAppender` components will not work, as they are hard-wired to connect to the main client.  As such, execution will need to be performed through the separate client instance.  If you wish to use the secondary cluster for logging, a new Appender will also need to be created.

--- a/modules/cbelasticsearch/docs/Configuration.md
+++ b/modules/cbelasticsearch/docs/Configuration.md
@@ -8,37 +8,48 @@ By default the following are in place, without additional configuration:
 ```
 moduleSettings = {
     "cbElasticsearch" = {
-        // The native client Wirebox DSL for the transport client
-        client = "JestClient@cbElasticsearch",
+        //The native client Wirebox DSL for the transport client
+        client="HyperClient@cbElasticsearch",
         // The default hosts - an array of host connections
         //  - REST-based clients (e.g. JEST):  round robin connections will be used
         //  - Socket-based clients (e.g. Transport):  cluster-aware routing used
+        versionTarget = getSystemSetting( "ELASTICSEARCH_VERSION", '' ),
         hosts = [
-            // The default connection is made to http://127.0.0.1:9200
+            //The default connection is made to http://127.0.0.1:9200
             {
-                serverProtocol = "http",
-                serverName = "127.0.0.1",
-                // Socket-based connections will use 9300
-                serverPort = "9200"
+                serverProtocol: getSystemSetting( "ELASTICSEARCH_PROTOCOL", "http" ),
+                serverName: getSystemSetting( "ELASTICSEARCH_HOST", "127.0.0.1" ),
+                serverPort: getSystemSetting( "ELASTICSEARCH_PORT", 9200 )
             }
         ],
+        // The default credentials for access, if any - may also be overridden when searching index collections
+        defaultCredentials = {
+            "username" : getSystemSetting( "ELASTICSEARCH_USERNAME", "" ),
+            "password" : getSystemSetting( "ELASTICSEARCH_PASSWORD", "" )
+        },
         // The default index
-        defaultIndex = "cbElasticsearch",
+        defaultIndex           = getSystemSetting( "ELASTICSEARCH_INDEX", "cbElasticsearch" ),
         // The default number of shards to use when creating an index
-        defaultIndexShards = 3,
+        defaultIndexShards     = getSystemSetting( "ELASTICSEARCH_SHARDS", 5 ),
         // The default number of index replicas to create
-        defaultIndexReplicas = 0,
+        defaultIndexReplicas   = getSystemSetting( "ELASTICSEARCH_REPLICAS", 0 ),
         // Whether to use separate threads for client transactions
-        multiThreaded = true,
+        multiThreaded          = true,
+        // The maximum amount of time to wait until releasing a connection (in seconds)
+        maxConnectionIdleTime = 30,
         // The maximum number of connections allowed per route ( e.g. search URI endpoint )
         maxConnectionsPerRoute = 10,
-        // The maxium number of connectsion, in total for all Elasticsearch requests
-        maxConnections = 100
+        // The maxium number of connections, in total for all Elasticsearch requests
+        maxConnections         = getSystemSetting( "ELASTICSEARCH_MAX_CONNECTIONS", 100 ),
+        // Read timeout - the read timeout in milliseconds
+        readTimeout            = getSystemSetting( "ELASTICSEARCH_READ_TIMEOUT", 3000 ),
+        // Connection timeout - timeout attempts to connect to elasticsearch after this timeout
+        connectionTimeout      = getSystemSetting( "ELASTICSEARCH_CONNECT_TIMEOUT", 3000 )
     }
 };
 ```
 
-At the current time only the REST-based [JEST] native client is available. Support is in development for a socket based-client.  For most applications, however the REST-based native client will be a good fit.
+At the current time only the REST-based [Hyper] native client is available. Support is in development for a socket based-client.  For most applications, however the REST-based native client will be a good fit.
 
 ## Connection to secondary Elasticsearch Clusters
 


### PR DESCRIPTION
This PR tweaks the module configuration documentation in two ways:

1. Updates the documentation on what the actual settings are by default. For example, the `client` default setting documentation was out of date, as well as `defaultIndexShards`, plus a number of settings were missing entirely. (And only noted in the "secondary Elasticsearch cluster" documentation.)
2. Adds a section for configuring cbElasticsearch via a `.env` file. Hopefully this isn't too explain-y, but I thought a simple copy/paste `.env` configuration would be useful for new devs. (and myself!)