### PR TITLE
Improves thrown exceptions with JSON packet

### DIFF
--- a/modules/cbelasticsearch/models/io/HyperClient.cfc
+++ b/modules/cbelasticsearch/models/io/HyperClient.cfc
@@ -1292,7 +1292,8 @@ component
     function onResponseFailure( required Hyper.models.HyperResponse response ){
         throw( 
             type = "cbElasticsearch.invalidRequest",
-            message = "Your request was invalid.  The response returned was #getUtil().toJSON( response.getData() )#"
+			message = "Your request was invalid.  The response returned was #getUtil().toJSON( response.getData() )#",
+			extendedInfo = isJSON( response.getData() ) ? response.getData() : getUtil().toJSON( response.getData() )
         );
 	}
 	

--- a/tests/specs/unit/HyperClientTest.cfc
+++ b/tests/specs/unit/HyperClientTest.cfc
@@ -318,6 +318,29 @@ component extends="coldbox.system.testing.BaseTestCase"{
 
 			});
 
+			it( "Tests error handling on executing search", function(){
+
+				var searchBuilder = getWirebox().getInstance( "SearchBuilder@cbElasticsearch" ).new( index="noSuchIndex", type="testdocs" );
+
+				// confirm it throws at all
+				expect( function(){
+					variables.model.executeSearch( searchBuilder );
+				}).toThrow( "cbElasticsearch.InvalidRequest" );
+
+				try{
+					variables.model.executeSearch( searchBuilder );
+				} catch( cbElasticsearch.InvalidRequest exception ){
+					// expectations on exception content
+					expect( isJSON( exception.extendedInfo ) ).toBeTrue();
+					var extendedError = deSerializeJSON( exception.extendedInfo );
+					expect( extendedError ).toHaveKey( "error" );
+					expect( extendedError.error ).toHaveKey( "root_cause" );
+					expect( extendedError.error.root_cause ).toBeArray();
+					expect( arrayLen( extendedError.error.root_cause ) ).toBeGT( 0 );
+				}
+
+			} );
+
 			it( "Tests the ability to count documents in an index", function(){
 
 				expect( variables ).toHaveKey( "testDocumentId" );


### PR DESCRIPTION
Adds the original Elasticsearch exception to the `extendedInfo` parameter of the exception. This allows consumers to easily deserialize the JSON and understand the original reason. Includes test for the new functionality.