### PR TITLE
Patch/add contributing docs

### DIFF
--- a/box.json
+++ b/box.json
@@ -19,7 +19,7 @@
         "hyper":"modules/hyper/"
     },
     "testbox":{
-        "runner":"http://localhost:49616"
+        "runner":"http://localhost:49616/tests/runner.cfm"
     },
     "scripts":{
         "postVersion":"recipe workbench/bump.boxr"

--- a/modules/cbelasticsearch/docs/Contributing.md
+++ b/modules/cbelasticsearch/docs/Contributing.md
@@ -1,0 +1,10 @@
+Contributing
+=============
+
+Follow these steps to get started hacking on CBElasticsearch.
+
+1. Clone the module - `git clone git@github.com:coldbox-modules/cbox-elasticsearch.git`
+2. Install dependencies - `box install`
+3. Start a new Elasticsearch instance via docker - `docker run -d -p "9200:9200" -e 'discovery.type=single-node' elasticsearch:7.6.2`
+4. Start the cbelasticsearch server - `box start`
+5. Run tests - `box testbox run`


### PR DESCRIPTION
Adds some basic documentation for getting started with contributions to the CBElasticsearch module... since [we already have a (broken) "Contributions" page on the CBElasticsearch gitbook](https://cbelasticsearch.ortusbooks.com/contributing).


Also fixes the `testbox.runner` setting in `box.json` so that `box testbox run` works. :smile: 