### PR TITLE
fix: Fixes document save error handling regression

### DIFF
--- a/modules/cbelasticsearch/models/io/HyperClient.cfc
+++ b/modules/cbelasticsearch/models/io/HyperClient.cfc
@@ -853,15 +853,15 @@ component
 		   { "document" : arguments.document }
 	   );
 
-       var saveResult = saveRequest
+       var saveResponse = saveRequest
                                 .setBody( 
                                     getUtil().toJSON( arguments.document.getMemento() ) 
                                 )
-								.send()
-								.json();
+								.send();
+		var saveResult = saveResponse.json();
 
 		if( structKeyExists( saveResult, "error" ) ){
-			onResponseFailure( saveResult );
+			onResponseFailure( saveResponse );
 		}
 
 		if( arguments.refresh ){


### PR DESCRIPTION
Fixes regression due to passing a hyper response body instead of a full hyper `Response` object.