### PR TITLE
fix: Fix HyperResponse "response is not json" error

### DIFF
--- a/modules/cbelasticsearch/models/io/HyperClient.cfc
+++ b/modules/cbelasticsearch/models/io/HyperClient.cfc
@@ -116,15 +116,16 @@ component
 				variables.versionTarget = configSettings.versionTarget;
 			} else {
 
-				var startPage = variables.nodePool
-                                .newRequest( 
-                                    "",
-                                    "GET"
+				try{
+
+					var startPage = variables.nodePool
+								.newRequest( 
+									"",
+									"GET"
 								)
 								.send()
 								.json();
 
-				try{
 					if( isSimpleValue( startPage.version ) ){
 						variables.versionTarget = startPage.version;
 					} else {


### PR DESCRIPTION
Fixes a Hyper response error when the Elasticsearch server is not started. Calling `.json()` on a non-JSON response will throw an error in Hyper. This is a simple way to detect if the elasticsearch server is not running or available.

![Screenshot from 2021-02-16 06-55-39](https://user-images.githubusercontent.com/8106227/108059939-38dbe200-7024-11eb-92fb-b2436f2a6ac1.png)