### PR TITLE
Add handling for string value error messages

### DIFF
--- a/modules/cbelasticsearch/models/util/Util.cfc
+++ b/modules/cbelasticsearch/models/util/Util.cfc
@@ -82,18 +82,23 @@ component accessors="true" singleton{
         if( !isSimpleValue( errorPayload ) ){
             errorReason = ( 
                 errorPayload.keyExists( "error" ) 
+                && !isSimpleValue( errorPayload.error )
                 && errorPayload.error.keyExists( "root_cause" )
             )
                 ? " Reason: #isArray( errorPayload.error.root_cause ) ? errorPayload.error.root_cause[ 1 ].reason : errorPayload.error.root_cause.reason#" 
                 : ( 
                     structKeyExists( errorPayload, "error" ) 
-                    ? " Reason: #errorPayload.error.reason#" 
+                    ? (
+                        isSimpleValue( errorPayload.error )
+                        ? " Reason: #errorPayload.error# "
+                        : " Reason: #errorPayload.error.reason#"
+                    )
                     : "" 
                 );
 
 
         }
-		if( len( errorReason ) && errorPayload.error.keyExists( "type" ) ){
+		if( len( errorReason ) && ! isSimpleValue( errorPayload.error ) && errorPayload.error.keyExists( "type" ) ){
 			throw(
                 type = "cbElasticsearch.native.#errorPayload.error.type#",
                 message = "An error was returned when communicating with the Elasticsearch server.  The error received was: #errorReason#",

--- a/tests/specs/unit/UtilTest.cfc
+++ b/tests/specs/unit/UtilTest.cfc
@@ -86,6 +86,40 @@ component extends="coldbox.system.testing.BaseTestCase"{
 
             });
 
+            it( "tests handleResponseError with a simple error string", function() {
+
+                var mockResponse = getMockBox().createMock( className="Hyper.models.HyperResponse" );
+
+                var mockError = serializeJSON( {
+                    "error" : "Incorrect HTTP method for uri [/myIndex/_doc] and method [PUT], allowed: [POST]"
+                } );
+                mockResponse.$( "getData", mockError );
+                mockResponse.$( "getStatusCode", 400 );
+
+                expect( function(){
+                    variables.model.handleResponseError( mockResponse );
+                } ).toThrow( "cbElasticsearch.invalidRequest" );
+            });
+
+            it( "tests handleResponseError with an error.reason struct", function() {
+
+                var mockResponse = getMockBox().createMock( className="Hyper.models.HyperResponse" );
+
+                var mockError = serializeJSON( {
+                    "error" : {
+                        "reason" : "This is a test of the nested error.reason exception format.",
+                        "type" : "BadDocument"
+                    },
+                    "status" : 400
+                } );
+                mockResponse.$( "getData", mockError );
+                mockResponse.$( "getStatusCode", 400 );
+
+                expect( function(){
+                    variables.model.handleResponseError( mockResponse );
+                } ).toThrow( "cbElasticsearch.native.BadDocument" );
+            });
+
         } );
 
     }


### PR DESCRIPTION
Elasticsearch seems to be a little conflicted with its exception message types! In the case of the wrong HTTP method, the error message does not come back as a nested `error.reason` value, but as a simple string in the `error` property.

This PR addresses that by checking for a simple value when parsing the exception message.

In addition, this PR adds a few tests to the `UtilTest.cfc` spec for handling `error.reason` and a simple `error: [string]` error message types.