### PR TITLE
Patch/issue 83 document setters overwritten

### DIFF
--- a/modules/cbelasticsearch/models/Document.cfc
+++ b/modules/cbelasticsearch/models/Document.cfc
@@ -95,10 +95,9 @@ component
 	* @type 	string 		The type of the document
 	**/
 	function get( string id, string index, string type ){
-
-		if( !structIsEmpty( arguments ) ){
-			structAppend( variables, arguments, true );
-		}
+		if ( !isNull( arguments.id ) ){ variables.id = arguments.id; }
+		if ( !isNull( arguments.index ) ){ variables.index = arguments.index; }
+		if ( !isNull( arguments.type ) ){ variables.type = arguments.type; }
 
 		if( isNull( variables.id ) ){
 			throw( 

--- a/tests/specs/unit/DocumentTest.cfc
+++ b/tests/specs/unit/DocumentTest.cfc
@@ -64,6 +64,29 @@ component extends="coldbox.system.testing.BaseTestCase"{
 			});
 
 
+			it( "Tests setters with get()", function(){
+
+				var testDocument = {
+					"_id"        : createUUID(),
+					"title"      : "My Test Document",
+					"createdTime": dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" )
+				};
+
+				var created = variables.model.new( variables.testIndexName, "testdocs", testDocument ).save();
+
+				expect( created ).toBeComponent();
+				variables.model.reset();
+
+				var found = variables.model.setIndex( variables.testIndexName )
+										.setId( testDocument[ "_id" ] )
+										.setType( "testdocs" )
+										.get();
+
+				expect( isNull( found ) ).toBeFalse();
+
+			});
+
+
 			it( "Tests the ability to persist a Document via save()", function(){
 
 				var testDocument = {


### PR DESCRIPTION
Resolves #83 by adding explicit `if()` conditionals for each argument. It turns out looping over an `arguments` struct is neither simple nor behaves as expected. In the end, I opted for straightforward repetition over confusing terseness.

Also added a simple test for the `Document.setIndex(...).setId( ... ).get()` behavior.
![Screenshot from 2021-04-26 09-49-16](https://user-images.githubusercontent.com/8106227/116094988-febb3c00-a675-11eb-9154-4cb0bf57cbb1.png)
