### PR TITLE
fix: Avoid reserved words which throw variable undefined error in Lucee

### DIFF
--- a/modules/cbelasticsearch/models/io/HyperClient.cfc
+++ b/modules/cbelasticsearch/models/io/HyperClient.cfc
@@ -243,19 +243,19 @@ component
 	**/
 	boolean function indexMappingExists( required string indexName ){
 
-        	var request =  variables.nodePool
-                        .newRequest( 
-                            arguments.indexName & '/_mapping',
-                            "GET"
-                        ).send();
+		var response =  variables.nodePool
+					.newRequest( 
+						arguments.indexName & '/_mapping',
+						"GET"
+					).send();
 
-		if( request.getStatusCode() >= 500 ) {
+		if( response.getStatusCode() >= 500 ) {
 			onResponseFailure( response );
 		} else {
 			return ( 
-				request.getStatusCode() == 200
+				response.getStatusCode() == 200
 				&&
-				!structIsEmpty( request.json() ) 
+				!structIsEmpty( response.json() ) 
 			);
 		}
 


### PR DESCRIPTION
The `request` variable causes an error in Lucee setups.