### PR TITLE
🐛 FIX: Add `dir.exports` variable definition for CI builds

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -49,7 +49,7 @@
 
 		<!-- Validation of required variables -->
 		<fail unless="project.name">A project name was not specified.  Build could not continue</fail>
-		<fail unless="project.version">A project version was not specified.  Build could not coutinue</fail>
+		<fail unless="project.version">A project version was not specified.  Build could not continue</fail>
 		<fail unless="module.name">A module name was not specified.  Build could not continue</fail>
 
 		<!-- Property defaults -->
@@ -82,6 +82,8 @@
 		
 		<!-- Build Label -->
 		<property name="build.label" value="${project.name}-${project.version}+${build.number}-${start.DSTAMP}${start.TSTAMP}"/>
+		<property name="dir.exports" value="${dir.artifacts}/${project.name}/${project.version}" />
+
 		<!-- Cleanup + Init -->
 		<delete dir="${dir.build}" />
 		<mkdir dir="${dir.build}"/>


### PR DESCRIPTION
The CI builds require `dir.exports` to be defined for the zip builds. Since [this commit to the unified workbench](https://github.com/Ortus-Solutions/unified-workbench/commit/f95e51de0839f1931c40889e37ac1fd2ad3d72cd) removed the dir.exports from `build.properties`, we need to define this in our custom `build.xml` in the cbElasticsearch repo.