### PR TITLE
🐛 FIX: Use correct directory for uploading of cbelasticsearch artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           name: cbelasticsearch
           path: |
-            build
+            artifacts
 
       - name: Upload Binaries to S3
         uses: jakejarvis/s3-sync-action@master
@@ -132,7 +132,7 @@ jobs:
           AWS_S3_BUCKET: "downloads.ortussolutions.com"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET }}
-          SOURCE_DIR: "build"
+          SOURCE_DIR: "artifacts"
           DEST_DIR: "ortussolutions/coldbox-modules/cbelasticsearch"
 
       - name: Deploy to Forgebox


### PR DESCRIPTION
The generated artifacts (`box-repo.json` and `cbelasticsearch-2.2.4.json`, for example) are generated and stored in the `artifacts/` dir, NOT in the `build/` dir!