### PR TITLE
🐛 FIX: More fixes for cbelasticsearch artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           name: cbelasticsearch
           path: |
-            artifacts
+            build
 
       - name: Upload Binaries to S3
         uses: jakejarvis/s3-sync-action@master
@@ -132,7 +132,7 @@ jobs:
           AWS_S3_BUCKET: "downloads.ortussolutions.com"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_ACCESS_SECRET }}
-          SOURCE_DIR: "artifacts"
+          SOURCE_DIR: "artifacts/cbelasticsearch"
           DEST_DIR: "ortussolutions/coldbox-modules/cbelasticsearch"
 
       - name: Deploy to Forgebox


### PR DESCRIPTION
The correct `exports.dir` directory is `artifacts/cbelasticsearch`.