### PR TITLE
📦 NEW: Add `error` getter/setter for tasks

### DIFF
--- a/modules/cbelasticsearch/models/Task.cfc
+++ b/modules/cbelasticsearch/models/Task.cfc
@@ -23,6 +23,7 @@ component accessors="true" {
 	property name="parent_task_id";
 	property name="headers";
 	property name="response";
+	property name="error";
 	property
 		name   ="completed"
 		type   ="boolean"
@@ -34,6 +35,9 @@ component accessors="true" {
 
 	public function populate( struct properties ){
 		if ( arguments.keyExists( "properties" ) ) {
+			if ( structKeyExists( arguments.properties, "error" ) ){
+				setError( arguments.properties.error );
+			}
 			if ( structKeyExists( arguments.properties, "task" ) ) {
 				var taskProperties = arguments.properties.task;
 				if ( structKeyExists( arguments.properties, "completed" ) ) {

--- a/modules/cbelasticsearch/models/Task.cfc
+++ b/modules/cbelasticsearch/models/Task.cfc
@@ -35,7 +35,7 @@ component accessors="true" {
 
 	public function populate( struct properties ){
 		if ( arguments.keyExists( "properties" ) ) {
-			if ( structKeyExists( arguments.properties, "error" ) ){
+			if ( structKeyExists( arguments.properties, "error" ) ) {
 				setError( arguments.properties.error );
 			}
 			if ( structKeyExists( arguments.properties, "task" ) ) {

--- a/tests/specs/unit/TaskTest.cfc
+++ b/tests/specs/unit/TaskTest.cfc
@@ -62,30 +62,22 @@ component extends="coldbox.system.testing.BaseTestCase" {
 						"cancellable"           : true
 					},
 					"error" : {
-						"position": {
-							"offset": 33,
-							"start": 16,
-							"end": 64
+						"position"  : { "offset" : 33, "start" : 16, "end" : 64 },
+						"script"    : " for ( test in ctx._source ){ ...",
+						"reason"    : "runtime error",
+						"type"      : "script_exception",
+						"lang"      : "painless",
+						"caused_by" : {
+							"reason" : "Cannot iterate over [java.util.HashMap]",
+							"type"   : "illegal_argument_exception"
 						},
-						"script": " for ( test in ctx._source ){ ...",
-						"reason": "runtime error",
-						"type": "script_exception",
-						"lang": "painless",
-						"caused_by": {
-							"reason": "Cannot iterate over [java.util.HashMap]",
-							"type": "illegal_argument_exception"
-						},
-						"script_stack": [
-							"for ( case in ctx._source ){ ",
-							" ^---- HERE"
-						]
+						"script_stack" : [ "for ( case in ctx._source ){ ", " ^---- HERE" ]
 					}
 				};
 				variables.model.populate( testTask );
 
 				expect( variables.model.getCompleted() ).toBe( testTask.completed );
-				expect( variables.model.getError() ).toBeTypeOf( "struct" )
-													.toHaveKey( "reason" );
+				expect( variables.model.getError() ).toBeTypeOf( "struct" ).toHaveKey( "reason" );
 			} );
 		} );
 	}

--- a/tests/specs/unit/TaskTest.cfc
+++ b/tests/specs/unit/TaskTest.cfc
@@ -47,6 +47,46 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 				expect( variables.model.isComplete() ).toBeTrue();
 			} );
+			it( "can get error details", function(){
+				expect( variables.model ).toBeInstanceOf( "cbElasticsearch.models.Task" );
+				var testTask = {
+					"completed" : false,
+					"task"      : {
+						"node"                  : "oTUltX4IQMOUUVeiohTt8A",
+						"id"                    : 464,
+						"type"                  : "transport",
+						"action"                : "indices:data/read/search",
+						"description"           : "indices[test], types[test], search_type[QUERY_THEN_FETCH], source[{""query"":...}]",
+						"start_time_in_millis"  : 1483478610008,
+						"running_time_in_nanos" : 13991383,
+						"cancellable"           : true
+					},
+					"error" : {
+						"position": {
+							"offset": 33,
+							"start": 16,
+							"end": 64
+						},
+						"script": " for ( test in ctx._source ){ ...",
+						"reason": "runtime error",
+						"type": "script_exception",
+						"lang": "painless",
+						"caused_by": {
+							"reason": "Cannot iterate over [java.util.HashMap]",
+							"type": "illegal_argument_exception"
+						},
+						"script_stack": [
+							"for ( case in ctx._source ){ ",
+							" ^---- HERE"
+						]
+					}
+				};
+				variables.model.populate( testTask );
+
+				expect( variables.model.getCompleted() ).toBe( testTask.completed );
+				expect( variables.model.getError() ).toBeTypeOf( "struct" )
+													.toHaveKey( "reason" );
+			} );
 		} );
 	}
 


### PR DESCRIPTION
Adds easier retrieval of task errors - for example, attempting to iterate over a HashMap will throw an illegal argument exception, but the task shows as "completed".