### PR TITLE
🚀Add a `filterRange()` searchBuilder method

### DIFF
--- a/modules/cbelasticsearch/models/SearchBuilder.cfc
+++ b/modules/cbelasticsearch/models/SearchBuilder.cfc
@@ -383,6 +383,35 @@ component accessors="true" {
 		return this;
 	}
 
+	/**
+	 * `range` filter for date ranges
+	 * @name 		string 		the key to match
+	 * @start 		string 		the preformatted date string to start the range
+	 * @end 			string 		the preformatted date string to end the range
+	 **/
+	 SearchBuilder function filterRange(
+		required string name,
+		string start,
+		string end
+	){
+		if ( isNull( arguments.start ) && isNull( arguments.end ) ) {
+			throw( type = "", message = "" );
+		}
+
+		var properties = {};
+		if ( !isNull( arguments.start ) ) {
+			properties[ "gte" ] = arguments.start;
+		}
+		if ( !isNull( arguments.end ) ) {
+			properties[ "lte" ] = arguments.end;
+		}
+		param variables.query.bool                  = {};
+		param variables.query.bool.filter           = {};
+		param variables.query.bool.filter.range     = { "#arguments.name#" : properties };
+
+		return this;
+	}
+
 	SearchBuilder function filterTerms(
 		required string name,
 		required any value,

--- a/modules/cbelasticsearch/models/SearchBuilder.cfc
+++ b/modules/cbelasticsearch/models/SearchBuilder.cfc
@@ -389,11 +389,7 @@ component accessors="true" {
 	 * @start 		string 		the preformatted date string to start the range
 	 * @end 			string 		the preformatted date string to end the range
 	 **/
-	 SearchBuilder function filterRange(
-		required string name,
-		string start,
-		string end
-	){
+	SearchBuilder function filterRange( required string name, string start, string end ){
 		if ( isNull( arguments.start ) && isNull( arguments.end ) ) {
 			throw( type = "", message = "" );
 		}
@@ -405,9 +401,9 @@ component accessors="true" {
 		if ( !isNull( arguments.end ) ) {
 			properties[ "lte" ] = arguments.end;
 		}
-		param variables.query.bool                  = {};
-		param variables.query.bool.filter           = {};
-		param variables.query.bool.filter.range     = { "#arguments.name#" : properties };
+		param variables.query.bool              = {};
+		param variables.query.bool.filter       = {};
+		param variables.query.bool.filter.range = { "#arguments.name#" : properties };
 
 		return this;
 	}

--- a/tests/specs/unit/SearchBuilderTest.cfc
+++ b/tests/specs/unit/SearchBuilderTest.cfc
@@ -255,6 +255,36 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
 			} );
 
+			it( "Tests the dateMatch() method", function() {
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+				var dateStart = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				var dateEnd = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				searchBuilder.dateMatch( "createdTime", dateStart, dateEnd, 2 );
+
+				expect( searchBuilder.getQuery() ).toBeStruct().toHaveKey( "bool" );
+				expect( searchBuilder.getQuery().bool ).toHaveKey( "must" );
+				expect( searchBuilder.getQuery().bool.must ).toBeArray().toHaveLength( 1 );
+				expect( searchBuilder.getQuery().bool.must[ 1 ] ).toHaveKey( "range" );
+				expect( searchBuilder.getQuery().bool.must[ 1 ].range ).toBeStruct().toHaveKey( "createdTime" );
+				expect( searchBuilder.getQuery().bool.must[ 1 ].range.createdTime ).toBeStruct().toHaveKey( "gte" ).toHaveKey( "lte" );
+
+				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
+			});
+			it( "Tests the filterRange() method", function() {
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+				var dateStart = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				var dateEnd = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				searchBuilder.filterRange( "createdTime", dateStart, dateEnd, 2 );
+
+				expect( searchBuilder.getQuery() ).toBeStruct().toHaveKey( "bool" );
+				expect( searchBuilder.getQuery().bool ).toHaveKey( "filter" );
+				expect( searchBuilder.getQuery().bool.filter ).toBeStruct().toHaveKey( "range" );
+				expect( searchBuilder.getQuery().bool.filter.range ).toBeStruct().toHaveKey( "createdTime" );
+				expect( searchBuilder.getQuery().bool.filter.range.createdTime ).toBeStruct().toHaveKey( "gte" ).toHaveKey( "lte" );
+
+				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
+			});
+
 			it( "Tests the mustExist() method", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
 

--- a/tests/specs/unit/SearchBuilderTest.cfc
+++ b/tests/specs/unit/SearchBuilderTest.cfc
@@ -255,10 +255,10 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
 			} );
 
-			it( "Tests the dateMatch() method", function() {
+			it( "Tests the dateMatch() method", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
-				var dateStart = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
-				var dateEnd = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				var dateStart     = dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				var dateEnd       = dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
 				searchBuilder.dateMatch( "createdTime", dateStart, dateEnd, 2 );
 
 				expect( searchBuilder.getQuery() ).toBeStruct().toHaveKey( "bool" );
@@ -266,24 +266,30 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.getQuery().bool.must ).toBeArray().toHaveLength( 1 );
 				expect( searchBuilder.getQuery().bool.must[ 1 ] ).toHaveKey( "range" );
 				expect( searchBuilder.getQuery().bool.must[ 1 ].range ).toBeStruct().toHaveKey( "createdTime" );
-				expect( searchBuilder.getQuery().bool.must[ 1 ].range.createdTime ).toBeStruct().toHaveKey( "gte" ).toHaveKey( "lte" );
+				expect( searchBuilder.getQuery().bool.must[ 1 ].range.createdTime )
+					.toBeStruct()
+					.toHaveKey( "gte" )
+					.toHaveKey( "lte" );
 
 				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
-			});
-			it( "Tests the filterRange() method", function() {
+			} );
+			it( "Tests the filterRange() method", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
-				var dateStart = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
-				var dateEnd = DateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				var dateStart     = dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
+				var dateEnd       = dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssXXX" );
 				searchBuilder.filterRange( "createdTime", dateStart, dateEnd, 2 );
 
 				expect( searchBuilder.getQuery() ).toBeStruct().toHaveKey( "bool" );
 				expect( searchBuilder.getQuery().bool ).toHaveKey( "filter" );
 				expect( searchBuilder.getQuery().bool.filter ).toBeStruct().toHaveKey( "range" );
 				expect( searchBuilder.getQuery().bool.filter.range ).toBeStruct().toHaveKey( "createdTime" );
-				expect( searchBuilder.getQuery().bool.filter.range.createdTime ).toBeStruct().toHaveKey( "gte" ).toHaveKey( "lte" );
+				expect( searchBuilder.getQuery().bool.filter.range.createdTime )
+					.toBeStruct()
+					.toHaveKey( "gte" )
+					.toHaveKey( "lte" );
 
 				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
-			});
+			} );
 
 			it( "Tests the mustExist() method", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );


### PR DESCRIPTION
This PR adds a `filterRange( name, start, end )` method to SearchBuilder to add in filtering by date start/end:

```js
var results = searchBuilder
                .new( "myData", "_doc" )
                .filterRange( "createdTime", rc.startDate, rc.endDate )
                .execute();
```

Note: I chose the name `filterRange()` to be consistent with the other `filterXYZ()` methods:

* `filterTerm()`
* `filterTerms()`
* `filterMatch()`

If you skim the PR too quickly, you'll notice this method is not named similarly to the `dateMatch()` filter. While that's a shame, I still think this is a consistent, good method name. 😃