### PR TITLE
📦 NEW: Add indexBuilder.delete( indexName ) support

### DIFF
--- a/modules/cbelasticsearch/models/IndexBuilder.cfc
+++ b/modules/cbelasticsearch/models/IndexBuilder.cfc
@@ -69,11 +69,11 @@ component accessors="true" {
 
 	/**
 	 * Deletes the index named in the configured builder
-	 * 
+	 *
 	 * @indexName Specify an index name to delete, if not already populated from the indexBuilder.new() method.
 	 **/
 	function delete( string indexName ){
-		if ( !isNull( arguments.indexName ) ){
+		if ( !isNull( arguments.indexName ) ) {
 			setIndexName( arguments.indexName );
 		}
 		return getClient().deleteIndex( this.getIndexName() );

--- a/modules/cbelasticsearch/models/IndexBuilder.cfc
+++ b/modules/cbelasticsearch/models/IndexBuilder.cfc
@@ -69,8 +69,13 @@ component accessors="true" {
 
 	/**
 	 * Deletes the index named in the configured builder
+	 * 
+	 * @indexName Specify an index name to delete, if not already populated from the indexBuilder.new() method.
 	 **/
-	function delete(){
+	function delete( string indexName ){
+		if ( !isNull( arguments.indexName ) ){
+			setIndexName( arguments.indexName );
+		}
 		return getClient().deleteIndex( this.getIndexName() );
 	}
 

--- a/tests/specs/unit/IndexBuilderTest.cfc
+++ b/tests/specs/unit/IndexBuilderTest.cfc
@@ -201,6 +201,15 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 				expect( variables.model.getClient().indexExists( variables.testIndexName ) ).toBeFalse();
 			} );
+			it( "Tests the delete() method with an index name argument", function(){
+				var shortLivedIndex = getWirebox().getInstance( "IndexBuilder@cbElasticSearch" ).new( variables.testIndexName );
+				shortLivedIndex.save();
+				expect( shortLivedIndex.getClient().indexExists( shortLivedIndex.getIndexName() ) ).toBeTrue();
+				
+				getWirebox().getInstance( "IndexBuilder@cbElasticSearch" ).delete( shortLivedIndex.getIndexName() );
+
+				expect( shortLivedIndex.getClient().indexExists( shortLivedIndex.getIndexName() ) ).toBeFalse();
+			} );
 		} );
 	}
 

--- a/tests/specs/unit/IndexBuilderTest.cfc
+++ b/tests/specs/unit/IndexBuilderTest.cfc
@@ -202,10 +202,12 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( variables.model.getClient().indexExists( variables.testIndexName ) ).toBeFalse();
 			} );
 			it( "Tests the delete() method with an index name argument", function(){
-				var shortLivedIndex = getWirebox().getInstance( "IndexBuilder@cbElasticSearch" ).new( variables.testIndexName );
+				var shortLivedIndex = getWirebox()
+					.getInstance( "IndexBuilder@cbElasticSearch" )
+					.new( variables.testIndexName );
 				shortLivedIndex.save();
 				expect( shortLivedIndex.getClient().indexExists( shortLivedIndex.getIndexName() ) ).toBeTrue();
-				
+
 				getWirebox().getInstance( "IndexBuilder@cbElasticSearch" ).delete( shortLivedIndex.getIndexName() );
 
 				expect( shortLivedIndex.getClient().indexExists( shortLivedIndex.getIndexName() ) ).toBeFalse();


### PR DESCRIPTION
IMHO, it feels funny to call `indexBuilder.new()` just to delete an index. Even the `new()` method is documented with a "Create a new index" hint - it's not just a weirdly-named init message.

TLDR: Adds support for an indexName argument so we can delete indices from the indexBuilder.