### PR TITLE
🐛 FIX: Correct sort order with string params

### DIFF
--- a/modules/cbelasticsearch/models/SearchBuilder.cfc
+++ b/modules/cbelasticsearch/models/SearchBuilder.cfc
@@ -900,7 +900,7 @@ component accessors="true" {
 		} else if ( isSimpleValue( arguments.sort ) && !isNull( arguments.sortConfig ) ) {
 			// Our sort config argument can be a complex struct or a simple value
 			variables.sorting.append( {
-				arguments.sort : isStruct( arguments.sortConfig ) ? arguments.sortConfig : {
+				"#arguments.sort#" : isStruct( arguments.sortConfig ) ? arguments.sortConfig : {
 					"order" : arguments.sortConfig
 				}
 			} );
@@ -933,7 +933,7 @@ component accessors="true" {
 	 *
 	 * @field  string the grouping field
 	 * @options a struct of additional options ( e.g. `inner_hits` )
-	 * @includeOccurrences whether to automatically aggreagate occurrences of each unique value
+	 * @includeOccurrences whether to automatically aggregate occurrences of each unique value
 	 */
 	SearchBuilder function collapseToField(
 		required string field,

--- a/tests/specs/unit/SearchBuilderTest.cfc
+++ b/tests/specs/unit/SearchBuilderTest.cfc
@@ -380,6 +380,20 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchbuilder.getSorting()[ 1 ].lastName.order ).toBe( "asc" );
 			} );
 
+			it( "Tests the sort() method by providing two strings", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+
+				searchBuilder.sort( "lastname", "asc" );
+
+				expect( searchBuilder.getSorting() ).toBeArray();
+				expect( searchBuilder.getSorting()[ 1 ] ).toBeStruct();
+				expect( searchbuilder.getSorting()[ 1 ] ).toHaveKey( "lastName" );
+
+				expect( searchbuilder.getSorting()[ 1 ].lastName ).toBeStruct();
+				expect( searchbuilder.getSorting()[ 1 ].lastName ).toHaveKey( "order" );
+				expect( searchbuilder.getSorting()[ 1 ].lastName.order ).toBe( "asc" );
+			} );
+
 			it( "Tests the default sort() method case of throwing an error", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
 


### PR DESCRIPTION
The [documented usage of the `sort()`](https://cbelasticsearch.ortusbooks.com/search#sorting-results) method is `sort( fieldName, direction )`. Too bad this syntax is the only one that doesn't work at the moment. :laughing: 

See the `ARGUMENTS` sort key in this screenshot:

![Screenshot from 2022-04-05 14-10-34](https://user-images.githubusercontent.com/8106227/161821949-5878ced0-b9b7-4996-8c60-7e34322db99b.png)

This PR 

* Adds a test for `sort( field, direction )`
* Fixes the `sort( field, direction )` sort syntax to behave as expected.
