### PR TITLE
Patch caching of index assurance

### DIFF
--- a/modules/cbelasticsearch/models/Client.cfc
+++ b/modules/cbelasticsearch/models/Client.cfc
@@ -227,7 +227,12 @@ component
 	 *
 	 * @return 	any 		Returns a Document object if found, otherwise returns null
 	 **/
-	any function get( required any id, string index, string type, struct params={} ){
+	any function get(
+		required any id,
+		string index,
+		string type,
+		struct params = {}
+	){
 		return variables.nativeClient.get( argumentCollection = arguments );
 	}
 

--- a/modules/cbelasticsearch/models/cache/Provider.cfc
+++ b/modules/cbelasticsearch/models/cache/Provider.cfc
@@ -610,7 +610,7 @@ component
 			arrayAppend( documents, document );
 		}
 
-		var transactionResult = getClient().saveAll( documents, true, { "refresh"  : "wait_for" } );
+		var transactionResult = getClient().saveAll( documents, true, { "refresh" : "wait_for" } );
 
 		var te = getTickCount();
 
@@ -667,7 +667,7 @@ component
 		document.setId( objectKey );
 
 		try {
-			var future = document.save( refresh=true );
+			var future = document.save( refresh = true );
 		} catch ( any e ) {
 			if ( isTimeoutException( e ) && getConfiguration().ignoreElasticsearchTimeouts ) {
 				// log it

--- a/modules/cbelasticsearch/models/io/HyperClient.cfc
+++ b/modules/cbelasticsearch/models/io/HyperClient.cfc
@@ -590,7 +590,12 @@ component accessors="true" threadSafe singleton {
 	 *
 	 * @return 	any 		Returns a Document object if found, otherwise returns null
 	 **/
-	any function get( required any id, string index, string type, struct params={} ){
+	any function get(
+		required any id,
+		string index,
+		string type,
+		struct params = {}
+	){
 		if ( isNull( arguments.index ) ) {
 			arguments.index = variables.instanceConfig.get( "defaultIndex" );
 		}
@@ -602,7 +607,7 @@ component accessors="true" threadSafe singleton {
 		var getRequest = variables.nodePool
 			.newRequest( "#arguments.index#/#arguments.type#/#urlEncodedFormat( arguments.id )#" )
 			.setThrowOnError( false );
-		
+
 		arguments.params
 			.keyArray()
 			.each( function( key ){

--- a/modules/cbelasticsearch/models/logging/LogstashAppender.cfc
+++ b/modules/cbelasticsearch/models/logging/LogstashAppender.cfc
@@ -233,7 +233,7 @@ component
 		variables.cachebox.getCache( instance.defaults.cacheName ).getOrSet(
 			"indexAssured_" & currentIndexName,
 			function(){
-				if ( getClient().indexExists( currentIndexName ) ) return;
+				if ( getClient().indexExists( currentIndexName ) ) return false;
 				indexBuilder().new( name = currentIndexName, properties = getIndexConfig() ).save();
 				return true;
 			}

--- a/modules/cbelasticsearch/models/logging/LogstashAppender.cfc
+++ b/modules/cbelasticsearch/models/logging/LogstashAppender.cfc
@@ -7,7 +7,7 @@ component
 	hint   ="This a logstash appender for Elasticsearch"
 {
 
-	property name="util" inject="Util@cbelasticsearch";
+	property name="util"     inject="Util@cbelasticsearch";
 	property name="cachebox" inject="cachebox";
 
 	/**
@@ -227,18 +227,15 @@ component
 	 * Verify or create the logging index
 	 */
 	private void function ensureIndex() output=false{
-
 		var currentIndexName = getRotationalIndexName();
 
-		variables.cachebox.getCache( instance.defaults.cacheName ).getOrSet(
-			"indexAssured_" & currentIndexName,
-			function(){
+		variables.cachebox
+			.getCache( instance.defaults.cacheName )
+			.getOrSet( "indexAssured_" & currentIndexName, function(){
 				if ( getClient().indexExists( currentIndexName ) ) return false;
 				indexBuilder().new( name = currentIndexName, properties = getIndexConfig() ).save();
 				return true;
-			}
-		);
-		
+			} );
 	}
 
 	private function getRotationalIndexName(){

--- a/tests/specs/unit/HyperClientTest.cfc
+++ b/tests/specs/unit/HyperClientTest.cfc
@@ -390,9 +390,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					variables.testDocumentId,
 					variables.testIndexName,
 					"testdocs",
-					{
-						"_source_includes" : "_id,title"
-					}
+					{ "_source_includes" : "_id,title" }
 				);
 
 				expect( isNull( document ) ).toBeFalse();
@@ -865,7 +863,10 @@ component extends="coldbox.system.testing.BaseTestCase" {
 						);
 					}
 
-					var savedDocs = variables.model.saveAll( documents=documents, params={ "refresh" : "wait_for" } );
+					var savedDocs = variables.model.saveAll(
+						documents = documents,
+						params    = { "refresh" : "wait_for" }
+					);
 
 					var searchOne = getWireBox()
 						.getInstance( "SearchBuilder@cbElasticSearch" )
@@ -890,8 +891,8 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					);
 
 					variables.model.reindex(
-						source      = variables.testIndexNameOne,
-						destination = variables.testIndexNameTwo,
+						source            = variables.testIndexNameOne,
+						destination       = variables.testIndexNameTwo,
 						waitForCompletion = true
 					);
 
@@ -938,7 +939,10 @@ component extends="coldbox.system.testing.BaseTestCase" {
 						);
 					}
 
-					var savedDocs = variables.model.saveAll( documents=documents, params={ "refresh" : "wait_for" } );
+					var savedDocs = variables.model.saveAll(
+						documents = documents,
+						params    = { "refresh" : "wait_for" }
+					);
 
 					var searchOne = getWireBox()
 						.getInstance( "SearchBuilder@cbElasticSearch" )

--- a/tests/specs/unit/UtilTest.cfc
+++ b/tests/specs/unit/UtilTest.cfc
@@ -2,7 +2,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 	function beforeAll(){
 		this.loadColdbox = true;
-		
+
 		super.beforeAll();
 
 		variables.model = getWirebox().getInstance( "Util@cbElasticSearch" );


### PR DESCRIPTION
Returning `void` breaks cachebox's `getOrSet()` helper. We need to return a boolean to fix this.