### PR TITLE
📦 NEW: Add formatToPainless() helper to Util for uglifying Painless scripts

### DIFF
--- a/models/util/Util.cfc
+++ b/models/util/Util.cfc
@@ -196,4 +196,14 @@ component accessors="true" singleton {
 		}
 	}
 
+	/**
+	 * Trim whitespace (newlines and tabs) from a script for safe parsing as a Painless script
+	 *
+	 * @script Prettified Elasticsearch script which is unfit for Painless
+	 * @returns uglified Painless-safe (newlines and tabs removed) single-line script.
+	 */
+	public string function formatToPainless( required string script ){
+		return reReplace( arguments.script, "\n|\r|\t", "", "ALL" );
+	}
+
 }

--- a/test-harness/tests/specs/unit/UtilTest.cfc
+++ b/test-harness/tests/specs/unit/UtilTest.cfc
@@ -104,6 +104,31 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					variables.model.handleResponseError( mockResponse );
 				} ).toThrow( "cbElasticsearch.native.BadDocument" );
 			} );
+
+			it( "can strip newlines and tabs from Painless scripts", function() {
+				var uglyScript = "ArrayList a = new ArrayList();";
+				var uglyScriptWithTabs = "ArrayList a = 		new ArrayList();";
+				var uglyScriptWithNewlines = "
+ArrayList a = new ArrayList();
+";
+
+				expect( variables.model.formatToPainless( uglyScript ) )
+					.toBe( uglyScript, "should leave ugly scripts alone." );
+				expect( variables.model.formatToPainless( uglyScriptWithTabs ) )
+					.toBe( "ArrayList a = new ArrayList();", "should strip tab characters." );
+				expect( variables.model.formatToPainless( uglyScriptWithNewlines ) )
+					.toBe( "ArrayList a = new ArrayList();", "should strip newline characters." );
+
+				var niceScript = "
+				ArrayList a = new ArrayList();
+				if (params._source.containsKey('isFree') && params._source.isFree != null) {
+					return 00.00;
+				}
+				";
+				var uglyScript = "ArrayList a = new ArrayList();if (params._source.containsKey('isFree') && params._source.isFree != null) {return 00.00;}";
+
+				expect( variables.model.formatToPainless( niceScript ) ).toBe( uglyScript, "should strip newlines and tabs" );
+			})
 		} );
 	}
 


### PR DESCRIPTION
This enables devs to write "clean" painless scripts and strip the newline/tab characters automatically:

```js
search.setScriptFields( {
    "thePrice": {
        "script": {
            "lang": "painless",
            "source": getInstance( "Util@cbElasticsearch" ).formatToPainless( myScript )
        }
    }
} );
```