### PR TITLE
📦 NEW: Add getIndexStats() for retrieving index statistics

### DIFF
--- a/docs/Indices/Managing-Indices.md
+++ b/docs/Indices/Managing-Indices.md
@@ -149,6 +149,45 @@ To retreive a list of the configured mappings for an index you may use the `getM
 var mappings = getInstance( "Client@CBElasticsearch" ).getMappings( "reviews" );
 ```
 
+## Getting Index Statistics
+
+To retrieve statistics on an index, use the `getIndexStats()` method:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" ).getIndexStats( "reviews" );
+```
+
+You can retrieve particular statistics metrics:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" )
+                    .getIndexStats( "reviews", [ "indexing", "search" ] );
+```
+
+Or all metrics:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" )
+                    .getIndexStats( "reviews", [ "_all" ] );
+```
+
+You can even retrieve all metrics on all indices by skipping the `indexName` parameter entirely:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" ).getIndexStats();
+```
+
+Finally, you can pass a struct of parameters to fine-tune the statistics result:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" )
+                    .getIndexStats(
+                        "reviews",
+                        [ "_all" ],
+                        { "level" : "shards", "fields" : "title,createdTime" }
+                    );
+```
+
 ## Deleting an Index
 
 All good things must come to an end, eh? You can use `Client.deleteIndex()` to delete an existing index:

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -481,6 +481,31 @@ component accessors="true" threadSafe singleton {
 	}
 
 	/**
+	 * Get statistics for the given index/indices.
+	 * 
+	 * @indexName 	string|array	Index name or alias. Can accept an array of index/alias names.
+	 * @metrics 	array			Array of index metrics to retrieve. I.e. `[ "completion","refresh", "request_cache" ]`.
+	 * @params		struct			Struct of query parameters to influence the request. For example: `{ "expand_wildcards" : "none", "level" : "shards" }
+	 */
+	struct function getIndexStats( any indexName, array metrics = [], struct params = {} ){
+		if ( isArray( arguments.indexName ) ){ arguments.indexName = arrayToList( arguments.indexName ); }
+	
+		var endpoint = [
+			"_stats"
+		];
+		if ( !isNull( arguments.indexName ) && arguments.indexName != "" ){
+			endpoint.prepend( arguments.indexName );
+		}
+		endpoint.append( arrayToList( metrics ) );
+		var statsRequest = variables.nodePool.newRequest( arrayToList( endpoint, "/" ), "get" );
+	
+		return statsRequest
+			.withQueryParams( arguments.params )
+			.send()
+			.json();
+	}
+
+	/**
 	 * Returns a struct containing all indices in the system, with statistics
 	 *
 	 * @verbose 	boolean 	whether to return the full stats output for the index

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -907,6 +907,28 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					sleep( 500 );
 				} );
 
+				it( "Tests getIndexStats method ", function(){
+					expect( variables ).toHaveKey( "testIndexName" );
+
+					var stats = variables.model.getIndexStats( variables.testIndexName, [ "_all" ] );
+
+					expect( stats.keyExists( "_all" ) ).toBeTrue();
+
+					// test with query params
+					stats = variables.model.getIndexStats(
+						variables.testIndexName,
+						[ "indexing", "search" ],
+						{ "level" : "shards" }
+					);
+
+					expect( stats.keyExists( "_all" ) ).toBeTrue();
+
+					// test with no index name == all indices
+					stats = variables.model.getIndexStats( indexName = "", metrics = [ "indexing" ] );
+
+					expect( stats.keyExists( "_all" ) ).toBeTrue();
+				} );
+
 				it( "Tests the ability to delete an index", function(){
 					expect( variables ).toHaveKey( "testIndexName" );
 					var deletion = variables.model.deleteIndex( variables.testIndexName );


### PR DESCRIPTION
This PR lets us retrieve statistics on an index using the `getIndexStats()` method:

```js
var mappings = getInstance( "Client@CBElasticsearch" )
                    .getIndexStats(
                        "reviews",
                        [ "_all" ],
                        { "level" : "shards", "fields" : "title,createdTime" }
                    );
```

- [x] Adds `getIndexStats()` to `HyperClient.cfc`
- [x] Adds test to `HyperClientTest.cfc`
- [x] Adds docs to `Indices/Managing-Indices.md`