### PR TITLE
👌 IMPROVE: Better index refreshing support

### DIFF
--- a/docs/Documents.md
+++ b/docs/Documents.md
@@ -119,6 +119,26 @@ You can also pass Document objects to the `Client`'s `save()` method:
 getInstance( "Client@cbElasticsearch" ).save( existingDocument );
 ```
 
+#### Save Documents with an Index Refresh
+
+If you need your document available immediately (such as during a test or pipeline), you can pass `refresh = true` to [instruct Elasticsearch to refresh the relevant index shard immediately and synchronously](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
+
+```js
+getInstance( "Client@cbElasticsearch" ).save(
+    document = existingDocument,
+    refresh = true
+);
+```
+
+The refresh parameter also accepts a `wait_for` option, which tells Elasticsearch to wait until the next index refresh:
+
+```js
+getInstance( "Client@cbElasticsearch" ).save(
+    document = existingDocument,
+    refresh = "wait_for"
+);
+```
+
 #### Updating individual document fields
 
 The `patch` method of the Client allows a user to update select fields, bypassing the need for a fully retrieved document.  This is similar to an `UPDATE foo SET bar = 'xyz' WHERE id = :id` query on a relational database.  The method requires an index name, identifier and a struct containing the keys to be updated:

--- a/docs/Indices/Managing-Indices.md
+++ b/docs/Indices/Managing-Indices.md
@@ -149,6 +149,31 @@ To retreive a list of the configured mappings for an index you may use the `getM
 var mappings = getInstance( "Client@CBElasticsearch" ).getMappings( "reviews" );
 ```
 
+## Triggering an index refresh
+
+On occasion, you may need to ensure the index is updated in real time (immediately and synchronously). This can be done via the `refreshIndex()` client method:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex( "reviews" );
+```
+
+You can refresh multiple indices at once:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex( [ "reviews", "books" ] );
+// OR
+var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex( "reviews,books" );
+```
+
+as well as pass [supported query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html#refresh-api-query-params) to the refresh endpoint. This can be useful when using wildcards in the index/alias names:
+
+```js
+var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex(
+    [ "reviews", "book*" ],
+    { "ignore_unavailable" : true }
+);
+```
+
 ## Deleting an Index
 
 All good things must come to an end, eh? You can use `Client.deleteIndex()` to delete an existing index:

--- a/models/Document.cfc
+++ b/models/Document.cfc
@@ -83,20 +83,18 @@ component accessors="true" {
 	/**
 	 * Persists the document to Elasticsearch
 	 *
-	 * @refresh  boolean if true, will return a newly populated instance of the document retreived from the index ( useful for pipelined saves )
+	 * @refresh  any if `true`, will return a newly populated instance of the document retreived from the index ( useful for pipelined saves ). if `"wait_for"`, will block until the next index refresh ingests the document update.
 	 **/
-	function save( boolean refresh = false ){
+	function save( any refresh = false ){
 		return getClient().save( this, arguments.refresh );
 	}
 
 	/**
 	 * Create-only method to save a document using the bulk API.  Will throw an error if the document already exists.
 	 *
-	 * @id 
-	 * @index 
-	 * @type 
+	 * @refresh
 	 */
-	function create( boolean refresh = false ){
+	function create( any refresh = false ){
 		var createOptions = {
 			"_index" : variables.index
 		};

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -481,6 +481,22 @@ component accessors="true" threadSafe singleton {
 	}
 
 	/**
+	 * Trigger an index refresh on the given index/indices.
+	 * 
+	 * @indexName 	string|array	Index name or alias. Can accept an array of index/alias names.
+	 * @params		struct			Struct of query parameters to influence the request. For example: `{ "ignore_unavailable" : true }`
+	 */
+	struct function refreshIndex( required any indexName, struct params ){
+		if ( isArray( arguments.indexName ) ){ arguments.indexName = arrayToList( arguments.indexName ); }
+		var refreshRequest = variables.nodePool.newRequest( "/#arguments.indexName#/_refresh", "post" );
+
+		return refreshRequest
+				.withQueryParams( arguments.params )
+				.send()
+				.json();
+	}
+
+	/**
 	 * Returns a struct containing all indices in the system, with statistics
 	 *
 	 * @verbose 	boolean 	whether to return the full stats output for the index

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -486,7 +486,7 @@ component accessors="true" threadSafe singleton {
 	 * @indexName 	string|array	Index name or alias. Can accept an array of index/alias names.
 	 * @params		struct			Struct of query parameters to influence the request. For example: `{ "ignore_unavailable" : true }`
 	 */
-	struct function refreshIndex( required any indexName, struct params ){
+	struct function refreshIndex( required any indexName, struct params = {} ){
 		if ( isArray( arguments.indexName ) ){ arguments.indexName = arrayToList( arguments.indexName ); }
 		var refreshRequest = variables.nodePool.newRequest( "/#arguments.indexName#/_refresh", "post" );
 

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -814,14 +814,14 @@ component accessors="true" threadSafe singleton {
 
 	/**
 	 * @document 		Document@cbElasticSearch 		An instance of the elasticsearch Document object
-	 * @refresh          boolean                         Whether to return a refreshed document - useful when processing via pipelines
+	 * @refresh  		any 							if `true`, will return a newly populated instance of the document retreived from the index ( useful for pipelined saves ). if `"wait_for"`, will block until the next index refresh ingests the document update.
 	 *
 	 * @return 			Document						The saved cbElasticsearch Document object
 	 * @interfaced
 	 **/
 	cbElasticsearch.models.Document function save(
 		required cbElasticsearch.models.Document document,
-		boolean refresh = false
+		any refresh
 	){
 		if ( isNull( arguments.document.getId() ) ) {
 			var saveRequest = variables.nodePool.newRequest( "#arguments.document.getIndex()#/_doc", "POST" );
@@ -832,8 +832,8 @@ component accessors="true" threadSafe singleton {
 			);
 		}
 
-		if ( arguments.refresh ) {
-			saveRequest.setQueryParam( "refresh", true );
+		if ( arguments.keyExists( "refresh" ) ) {
+			saveRequest.setQueryParam( "refresh", arguments.refresh );
 		}
 
 		if ( !isNull( arguments.document.getPipeline() ) ) {
@@ -859,7 +859,7 @@ component accessors="true" threadSafe singleton {
 
 		arguments.document.setId( saveResult[ "_id" ] );
 
-		if ( arguments.refresh && !isNull( arguments.document.getPipeline() ) ) {
+		if ( arguments.keyExists( "refresh" ) && arguments.refresh == true && !isNull( arguments.document.getPipeline() ) ) {
 			arguments.document = this.get( saveResult[ "_id" ], arguments.document.getIndex() );
 		}
 

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -202,6 +202,33 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 					variables.testDocumentId = saveResult.getId();
 				} );
+				it( "Tests document save with refresh=wait_for", function(){
+					expect( variables ).toHaveKey( "testIndexName" );
+
+					var testDocument = {
+						"_id"         : createUUID(),
+						"title"       : "My Test Document",
+						"createdTime" : dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" )
+					};
+
+					var document = getWirebox()
+						.getInstance( "Document@cbElasticsearch" )
+						.new(
+							variables.testIndexName,
+							"_doc",
+							testDocument
+						);
+
+					var saveResult = variables.model.save( document, "wait_for" );
+
+					expect( saveResult ).toBeComponent();
+					expect( saveResult.getId() ).toBe( testDocument[ "_id" ] );
+
+					var existingDocument = getWirebox()
+						.getInstance( "Document@cbElasticsearch" )
+						.get( saveResult.getId(), variables.testIndexName );
+					expect( existingDocument ).notToBeNull();
+				} );
 
 				describe( "parseParams method tests", function(){
 					it( "can accept an query string", function(){

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -956,6 +956,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					expect( refreshResult ).toHaveKey( "_shards" );
 					expect( refreshResult._shards ).toHaveKey( "total" );
 					expect( refreshResult._shards.total ).toBe( 0 );
+				} );
 
 				it( "Tests getIndexStats method ", function(){
 					expect( variables ).toHaveKey( "testIndexName" );

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -934,6 +934,30 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					sleep( 500 );
 				} );
 
+				it( "Tests refreshIndex method ", function(){
+					expect( variables ).toHaveKey( "testIndexName" );
+
+					// test against existing index
+					var refreshResult = variables.model.refreshIndex( variables.testIndexName );
+
+					expect( refreshResult.keyExists( "_shards" ) ).toBeTrue();
+					expect( refreshResult.keyExists( "error" ) ).toBeFalse();
+
+					// test against nonexistent index
+					refreshResult = variables.model.refreshIndex( "doesnotexist" );
+
+					expect( refreshResult.keyExists( "error" ) ).toBeTrue();
+					expect( refreshResult.status ).toBe( "404" );
+
+					// test against nonexistent index, with ignore nonexistent
+					refreshResult = variables.model.refreshIndex( [ "doesnotexist", "alsonotexist" ], { "ignore_unavailable" : true } );
+
+					expect( refreshResult.keyExists( "error" ) ).toBeFalse();
+					expect( refreshResult ).toHaveKey( "_shards" );
+					expect( refreshResult._shards ).toHaveKey( "total" );
+					expect( refreshResult._shards.total ).toBe( 0 );
+				} );
+
 				it( "Tests the ability to delete an index", function(){
 					expect( variables ).toHaveKey( "testIndexName" );
 					var deletion = variables.model.deleteIndex( variables.testIndexName );


### PR DESCRIPTION
This PR lets us trigger an index(es) refresh using `client.refreshIndex()`:

```js
var mappings = getInstance( "Client@CBElasticsearch" )
                    .refreshIndex( [ "reviews", "book*" ], { "ignore_unavailable" : true } );
```

In addition, this PR updates the client's `save()` method to accept `refresh = "wait_for"`:

```js
getInstance( "Client@cbElasticsearch" ).save(
    document = existingDocument,
    refresh = "wait_for"
);
```

- [x] Adds `refreshIndex()` method to `HyperClient.cfc`
- [x] Adds test to `HyperClientTest.cfc`
- [x] Adds `refreshIndex()` docs to `docs/Indices/Managing-Indices.md`
- [x] Adds `refresh = "wait_for"` docs to `docs/Documents.md`