### PR TITLE
📦 NEW: Add support for script fields and runtime fields

### DIFF
--- a/docs/Indices/Managing-Indices.md
+++ b/docs/Indices/Managing-Indices.md
@@ -240,7 +240,7 @@ getInstance( "Client@CBElasticsearch" )
         } );
 ```
 
-This `summarized_emotions` field [can then be retrieve during a search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html) to display an array of emotions matching the review summary.
+This `summarized_emotions` field [can then be retrieved during a search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html) to display an array of emotions matching the review summary.
 
 ## Deleting an Index
 

--- a/docs/Indices/Managing-Indices.md
+++ b/docs/Indices/Managing-Indices.md
@@ -172,6 +172,7 @@ var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex(
     [ "reviews", "book*" ],
     { "ignore_unavailable" : true }
 );
+```
 
 ## Getting Index Statistics
 
@@ -211,6 +212,35 @@ var mappings = getInstance( "Client@CBElasticsearch" )
                         { "level" : "shards", "fields" : "title,createdTime" }
                     );
 ```
+
+## Creating Runtime Fields
+
+Elasticsearch allows [mapping runtime fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html), which are fields calculated at search time and returned in the `"fields"` array.
+
+```js
+var script = getInstance( "Util@CBElasticsearch" )
+.formatToPainless("
+  if( doc['summary'].value.contains('love') ){ emit('😍');}
+  if( doc['summary'].value.contains('great') ){ emit('🚀');}
+  if( doc['summary'].value.contains('hate') ){ emit('😡');}
+  if( doc['summary'].value.contains('broke') ){ emit('💔');}
+");
+getInstance( "Client@CBElasticsearch" )
+        .patch( "reviews", {
+            "mappings" : {
+                "runtime" : {
+                    "summarized_emotions" : {
+                        "type" : "text",
+                        "script" : {
+                            "source" : script
+                        }
+                    }
+                }
+            }
+        } );
+```
+
+This `summarized_emotions` field [can then be retrieve during a search](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html) to display an array of emotions matching the review summary.
 
 ## Deleting an Index
 

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -121,6 +121,38 @@ searchBuilder.sort( "author.age", "DESC" );
 For more information on sorting search results, check out [Elasticsearch: Sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/sort-search-results.html#sort-search-results)
 {% endhint %}
 
+### Script Fields
+
+SearchBuilder also supports [Elasticsearch script fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#script-fields), which allow you to evaluate field values at search time for each document hit:
+
+```js
+searchBuilder.setScriptFields( {
+    "interestCost": {
+        "script": {
+            "lang": "painless",
+            "source": getInstance( "Util@cbElasticsearch" )
+                .formatToPainless( "
+                return doc['price'].size() != 0
+                    ? doc['price'].value * (params.interestRate/100)
+                    : null
+                " ),
+            "params": { "interestRate": 5.5 }
+        }
+    }
+} );
+searchBuilder.setSource( true );
+```
+
+This will result in an `"interestCost"` field in the `scriptFields` struct on the `Document` object:
+
+```js
+var interest = searchBuilder.getHits().map( (document) => document.getScriptFields()["interestCost"] ); // 5.50
+```
+
+How *interesting*. 😜
+
+***Note**: Currently, using script fields seems to require enabling the `_source` field: `setSource( true )`. Don't forget this step!*
+
 ### Advanced Query DSL
 
 The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing full configuration of your search queries. There are several methods to provide the raw query language to the Search Builder. One is during instantiation.

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -135,12 +135,34 @@ searchBuilder.addScriptField( "interestCost",{
 } );
 ```
 
-This will result in an `"interestCost"` field in the `scriptFields` struct on the `Document` object:
+This will result in an `"interestCost"` field in the `fields` property on the `Document` object:
 
 ```js
-var interest = searchBuilder.getHits().map( (document) => document.getScriptFields()["interestCost"] ); // 5.50
+var interest = searchBuilder.execute().getHits().map( (document) => document.getFields()["interestCost"] ); // 5.50
 ```
 
+In a similar fashion, runtime fields can also be fetched and will appear in the document's `fields` struct. This example retrieves the `"fuel_usage_in_mpg"` runtime field as well as the indexed `"make"` and `"model"` fields:
+
+```js
+var hits = searchBuilder.new( "itinerary" )
+             .setFields( [ "fuel_usage_in_mpg", "make", "model" ] )
+             .execute()
+             .getHits();
+for( hit in hits ){
+    var result = hit.getFields();
+    writeOutput( "This #result.make# #result.model# gets #fuel_mpg#/gallon" );
+}
+```
+
+To access document `fields` as well as the `_source` properties, use`hit.getDocument( includeFields = true)`:
+
+```js
+var result = searchBuilder.execute();
+for( hit in result.getHits() ){
+    var document = document.getDocuments( includeFields = true );
+    writeOutput( "This #document.make# #document.model# gets #fuel_mpg#/gallon" );
+}
+```
 
 ### Advanced Query DSL
 

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -141,13 +141,33 @@ This will result in an `"interestCost"` field in the `fields` property on the `D
 var interest = searchBuilder.execute().getHits().map( (document) => document.getFields()["interestCost"] ); // 5.50
 ```
 
-In a similar fashion, runtime fields can also be fetched and will appear in the document's `fields` struct. This example retrieves the `"fuel_usage_in_mpg"` runtime field as well as the indexed `"make"` and `"model"` fields:
+### Runtime Fields
+
+Elasticsearch also allows the creation of runtime fields, which are fields defined in the index mapping but populated at search time via a script.
+
+{% hint style="info" %}
+See [Managing-Indices](../Indices/Managing-Indices.md#creating-runtime-fields) for more information on creating runtime fields.
+{% endhint %}
+
+Runtime fields can be fetched via the `setFields()` or `addField()` methods, and will appear in the `Document` object's `fields` struct. This example retrieves the `"fuel_usage_in_mpg"` runtime field as well as the indexed `"make"` and `"model"` fields:
 
 ```js
 var hits = searchBuilder.new( "itinerary" )
-             .setFields( [ "fuel_usage_in_mpg", "make", "model" ] )
+             .setFields( [ "fuel_mpg", "make", "model" ] )
              .execute()
              .getHits();
+// OR
+var hits = searchBuilder.new( "itinerary" )
+             .addField( "fuel_mpg" )
+             .addField( "make" )
+             .addField( "model" )
+             .execute()
+             .getHits();
+```
+
+Once you have a search response, you can use the `.getFields()` method to retrieve the specified fields from the search document:
+
+```js
 for( hit in hits ){
     var result = hit.getFields();
     writeOutput( "This #result.make# #result.model# gets #fuel_mpg#/gallon" );
@@ -159,7 +179,7 @@ To access document `fields` as well as the `_source` properties, use`hit.getDocu
 ```js
 var result = searchBuilder.execute();
 for( hit in result.getHits() ){
-    var document = document.getDocuments( includeFields = true );
+    var document = document.getDocument( includeFields = true );
     writeOutput( "This #document.make# #document.model# gets #fuel_mpg#/gallon" );
 }
 ```

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -126,21 +126,13 @@ For more information on sorting search results, check out [Elasticsearch: Sort s
 SearchBuilder also supports [Elasticsearch script fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#script-fields), which allow you to evaluate field values at search time for each document hit:
 
 ```js
-searchBuilder.setScriptFields( {
-    "interestCost": {
-        "script": {
-            "lang": "painless",
-            "source": getInstance( "Util@cbElasticsearch" )
-                .formatToPainless( "
-                return doc['price'].size() != 0
-                    ? doc['price'].value * (params.interestRate/100)
-                    : null
-                " ),
-            "params": { "interestRate": 5.5 }
-        }
+searchBuilder.addScriptField( "interestCost",{
+    "script": {
+        "lang": "painless",
+        "source": "return doc['price'].size() != 0 ? doc['price'].value * (params.interestRate/100): null",
+        "params": { "interestRate": 5.5 }
     }
 } );
-searchBuilder.setSource( true );
 ```
 
 This will result in an `"interestCost"` field in the `scriptFields` struct on the `Document` object:
@@ -149,9 +141,6 @@ This will result in an `"interestCost"` field in the `scriptFields` struct on th
 var interest = searchBuilder.getHits().map( (document) => document.getScriptFields()["interestCost"] ); // 5.50
 ```
 
-How *interesting*. 😜
-
-***Note**: Currently, using script fields seems to require enabling the `_source` field: `setSource( true )`. Don't forget this step!*
 
 ### Advanced Query DSL
 

--- a/models/Document.cfc
+++ b/models/Document.cfc
@@ -46,6 +46,10 @@ component accessors="true" {
 	 */
 	property name="params";
 
+	/**
+	 * Any evaluated script field results
+	 */
+	property name="scriptFields" type="struct";
 
 	function onDIComplete(){
 		reset();

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -1234,4 +1234,25 @@ component accessors="true" {
 		return this;
 	}
 
+	/**
+	 * Append a field name or object in the list of fields to return.
+	 * 
+	 * Especially useful for runtime fields.
+	 * 
+	 * Example:
+	 * ```
+	 * addField( { "field": "@timestamp", "format": "epoch_millis"  } )
+	 * ```
+	 * 
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-retrieving-fields.html#runtime-search-dayofweek
+	 *
+	 * @value string|struct Field name to retrieve OR struct config
+	 */
+	public SearchBuilder function addField( required any value ){
+		if ( isNull( variables.fields ) ){
+			variables.fields = [];
+		}
+		variables.fields.append( arguments.value );
+		return this;
+	}
 }

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -55,7 +55,14 @@ component accessors="true" {
 	 * 
 	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#script-fields
 	 */
-    property name="scriptFields" type="struct";
+	property name="scriptFields" type="struct";
+
+	/**
+	 * Property containing "fields" array of fields to return for each hit
+	 * 
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html
+	 */
+	property name="fields" type="array";
 
 	/**
 	 * When performing matching searches, the type of match to specify
@@ -1112,6 +1119,10 @@ component accessors="true" {
 			dsl[ "script_fields" ] = variables.scriptFields;
 		}
 
+		if ( !isNull( variables.fields ) ) {
+			dsl[ "fields" ] = variables.fields;
+		}
+
 		if ( !isNull( variables.sorting ) ) {
 			// we used a linked hashmap for sorting to maintain order
 			dsl[ "sort" ] = createObject( "java", "java.util.LinkedHashMap" ).init();
@@ -1173,6 +1184,11 @@ component accessors="true" {
 	function setSourceExcludes( array excludes = [] ){
 		param variables.source    = { "includes" : [], "excludes" : [] };
 		variables.source.excludes = arguments.excludes;
+		return this;
+	}
+
+	public SearchBuilder function setFields( array fields = [] ){
+		variables.fields = arguments.fields;
 		return this;
 	}
 

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -51,6 +51,13 @@ component accessors="true" {
 	property name="script";
 
 	/**
+	 * Property containing elasticsearch "script_fields" definition for runtime scripted fields
+	 * 
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#script-fields
+	 */
+    property name="scriptFields" type="struct";
+
+	/**
 	 * When performing matching searches, the type of match to specify
 	 **/
 	property name="matchType";
@@ -1099,6 +1106,10 @@ component accessors="true" {
 
 		if ( !isNull( variables.script ) ) {
 			dsl[ "script" ] = variables.script;
+		}
+
+		if ( !isNull( variables.scriptFields ) ) {
+			dsl[ "script_fields" ] = variables.scriptFields;
 		}
 
 		if ( !isNull( variables.sorting ) ) {

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -1176,4 +1176,20 @@ component accessors="true" {
 		return this;
 	}
 
+	/**
+	 * Append a dynamic script field to the search.
+	 *
+	 * @name Name of the script field
+	 * @script Script to use. `{ "script" : { "lang": "painless", "source" : } }`
+	 * @source Which _source values to include in the response. `true` for all, `false` for none, or a wildcard-capable string: `source = "author.*"`
+	 */
+	public SearchBuilder function addScriptField( required string name, struct script, any source = true ){
+		if ( isNull( variables.scriptFields ) ){
+			variables.scriptFields = {};
+		}
+		variables.scriptFields[ arguments.name ] = arguments.script;
+		setSource( arguments.source );
+		return this;
+	}
+
 }

--- a/models/SearchResult.cfc
+++ b/models/SearchResult.cfc
@@ -143,7 +143,8 @@ component accessors="true" {
 		variables.hits = [];
 
 		for ( var hit in arguments.hits ) {
-			var doc = newDocument().populate( hit[ "_source" ] );
+			var documentSource = hit.keyExists( "_source" ) ? hit[ "_source" ] : {};
+			var doc = newDocument().populate( documentSource );
 
 			doc.setIndex( hit[ "_index" ] );
 
@@ -162,7 +163,7 @@ component accessors="true" {
 			}
 
 			if ( structKeyExists( hit, "fields" ) ) {
-				doc.setScriptFields( hit[ "fields" ] );
+				doc.setFields( hit[ "fields" ] );
 			}
 
 			arrayAppend( variables.hits, doc );

--- a/models/SearchResult.cfc
+++ b/models/SearchResult.cfc
@@ -161,6 +161,10 @@ component accessors="true" {
 				doc.setHighlights( hit[ "highlight" ] );
 			}
 
+			if ( structKeyExists( hit, "fields" ) ) {
+				doc.setScriptFields( hit[ "fields" ] );
+			}
+
 			arrayAppend( variables.hits, doc );
 		}
 

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -311,6 +311,7 @@ component accessors="true" threadSafe singleton {
 			&& structKeyExists( indexDSL, "mappings" )
 			&& !structIsEmpty( indexDSL.mappings )
 			&& !structKeyExists( indexDSL.mappings, "properties" )
+			&& !structKeyExists( indexDSL.mappings, "runtime" )
 		) {
 			if ( indexDSL.mappings.keyArray().len() > 1 ) {
 				throw(

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -690,7 +690,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 						"testdocs"
 					)
 					.filterTerm( "price_in_cents", "999" )
-					.setFields( [ "price_in_cents" ] );
+					.addField( "price_in_cents" );
 
 					var hits = variables.model.executeSearch( searchBuilder ).getHits();
 					expect( hits.len() ).toBeGT( 0 );

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -634,16 +634,13 @@ component extends="coldbox.system.testing.BaseTestCase" {
 						{ "match_all" : {} }
 					);
 	
-					searchBuilder.setScriptFields( {
-						"interestCost": {
-							"script": {
-								"lang": "painless",
-								"source": "return doc['price'].size() != 0 ? doc['price'].value * (params.interestRate/100) : null;",
-								"params": { "interestRate": 5.5 }
-							}
+					searchBuilder.addScriptField( "interestCost", {
+						"script": {
+							"lang": "painless",
+							"source": "return doc['price'].size() != 0 ? doc['price'].value * (params.interestRate/100) : null;",
+							"params": { "interestRate": 5.5 }
 						}
 					} );
-					searchBuilder.setSource( true );
 	
 					var hits = variables.model.executeSearch( searchBuilder ).getHits();
 					expect( hits.len() ).toBeGT( 0 );

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -21,10 +21,6 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 	function run(){
 		describe( "Performs cbElasticsearch HyperClient tests", function(){
-			afterEach( function(){
-				// we give ourselves a few seconds before each next test for updates to persist
-				sleep( 500 );
-			} );
 
 			it( "Tests the ability to create an index", function(){
 				var builderProperties = {
@@ -53,10 +49,6 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			} );
 
 			describe( "Index mappings and settings and utility methods", function(){
-				afterEach( function(){
-					// we give ourselves a few seconds before each next test for updates to persist
-					sleep( 500 );
-				} );
 
 				it( "Tests the ability to update mappings in an index", function(){
 
@@ -173,10 +165,6 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			} );
 
 			describe( "Document tests", function(){
-				afterEach( function(){
-					// we give ourselves a few seconds before each next test for updates to persist
-					sleep( 500 );
-				} );
 
 
 				it( "Tests the ability to insert a document in to an index", function(){
@@ -545,11 +533,6 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 			describe( "Search tests", function(){
 
-				afterEach( function(){
-					// we give ourselves a few seconds before each next test for updates to persist
-					sleep( 500 );
-				} );
-
 				it( "Tests the ability to process a search on an index", function(){
 					expect( variables ).toHaveKey( "testDocumentId" );
 
@@ -721,11 +704,6 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			} );
 
 			describe( "More fun with documents", function(){
-
-				afterEach( function(){
-					// we give ourselves a few seconds before each next test for updates to persist
-					sleep( 500 );
-				} );
 
 				it( "Tests the ability to patch a document with a single field value", function(){
 					expect( variables ).toHaveKey( "testDocumentId" );
@@ -1004,10 +982,6 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			} );
 
 			describe( "Post index creation tests", function(){
-				afterEach( function(){
-					// we give ourselves a few seconds before each next test for updates to persist
-					sleep( 500 );
-				} );
 
 				it( "Tests refreshIndex method ", function(){
 					expect( variables ).toHaveKey( "testIndexName" );

--- a/test-harness/tests/specs/unit/SearchBuilderTest.cfc
+++ b/test-harness/tests/specs/unit/SearchBuilderTest.cfc
@@ -762,15 +762,11 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			it( "Tests the setScriptFields() method", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
 
-				var theScript = getWirebox().getInstance( "Util@cbElasticsearch" )
-					.formatToPainless( "
-						params._source['price'].value * .95
-					");
 				searchBuilder.setScriptFields( {
 					"with5PercentDiscount": {
 						"script": {
 							"lang": "painless",
-							"source": theScript
+							"source": "doc['price'].value * 2"
 						}
 					}
 				} );
@@ -778,6 +774,36 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.getDSL() ).toBeStruct();
 				expect( searchBuilder.getDSL() ).toHaveKey( "script_fields" );
 				expect( searchBuilder.getDSL()[ "script_fields" ] ).toHaveKey( "with5PercentDiscount" );
+			} );
+
+			it( "Tests the addScriptField() method", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+
+				searchBuilder.addScriptField( "with5PercentDiscount", {
+					"script": {
+						"lang": "painless",
+						"source": "doc['price'].value * 2"
+					}
+				} );
+	
+				expect( searchBuilder.getDSL() ).toBeStruct().toHaveKey( "script_fields" );
+				expect( searchBuilder.getDSL()[ "script_fields" ] ).toHaveKey( "with5PercentDiscount" );
+			} );
+
+			it( "Tests the addField() method for retrieving runtime or other fields", function(){
+				var search = variables.model.new( variables.testIndexName, "testdocs" );
+
+				search.addField( "day_of_week" )
+						.addField( "name_full" )
+						.addField( {
+							"field": "@timestamp",
+							"format": "epoch_millis" 
+						} );
+	
+				expect( search.getDSL() ).toBeStruct().toHaveKey( "fields" );
+				expect( search.getDSL()[ "fields" ] ).toBeArray()
+					.toInclude( "day_of_week" )
+					.toInclude( "name_full" );
 			} );
 
 			it( "Tests the both the setSourceIncludes() and setSourceExcludes() methods", function(){

--- a/test-harness/tests/specs/unit/SearchBuilderTest.cfc
+++ b/test-harness/tests/specs/unit/SearchBuilderTest.cfc
@@ -21,7 +21,8 @@ component extends="coldbox.system.testing.BaseTestCase" {
 							"_all"       : { "enabled" : false },
 							"properties" : {
 								"title"       : { "type" : "text" },
-								"createdTime" : { "type" : "date", "format" : "date_time_no_millis" }
+								"createdTime" : { "type" : "date", "format" : "date_time_no_millis" },
+								"price"       : { "type" : "float" }
 							}
 						}
 					}
@@ -752,6 +753,27 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.getDSL()[ "_source" ][ "includes" ] ).toBe( [] );
 				expect( searchBuilder.getDSL()[ "_source" ] ).toHaveKey( "excludes" );
 				expect( searchBuilder.getDSL()[ "_source" ][ "excludes" ] ).toBe( [ "*.description" ] );
+			} );
+
+			it( "Tests the setScriptFields() method", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+
+				var theScript = getWirebox().getInstance( "Util@cbElasticsearch" )
+					.formatToPainless( "
+						params._source['price'].value * .95
+					");
+				searchBuilder.setScriptFields( {
+					"with5PercentDiscount": {
+						"script": {
+							"lang": "painless",
+							"source": theScript
+						}
+					}
+				} );
+	
+				expect( searchBuilder.getDSL() ).toBeStruct();
+				expect( searchBuilder.getDSL() ).toHaveKey( "script_fields" );
+				expect( searchBuilder.getDSL()[ "script_fields" ] ).toHaveKey( "with5PercentDiscount" );
 			} );
 
 			it( "Tests the both the setSourceIncludes() and setSourceExcludes() methods", function(){


### PR DESCRIPTION
This allows developers to return a custom value calculated for each document hit:

```js
searchBuilder.setScriptFields( {
    "interestCost": {
        "script": {
            "lang": "painless",
            "source": "return doc['price'].size() != 0 ? doc['price'].value * (params.interestRate/100) : null ",
            "params": { "interestRate": 5.5 }
        }
    }
} );
searchBuilder.setSource( true );
...
var interest = searchBuilder.getHits().map( (document) => document.getScriptFields()["interestCost"] );
```

- [x] Includes test 🤖
- [x] Includes docs 📖