### PR TITLE
📦 NEW: Add terms enum query for fetching autocompletion terms match

### DIFF
--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -238,6 +238,32 @@ SearchBuilder.highlight( {
 })
 ```
 
+## Terms Enum
+
+On occasion, you may wish to show a set of terms matching a partial string. This is similar to aggregations, only filtered by the provided string and intended for autocompletion.
+
+To retrieve this data, you can use the client's `getTermsEnum()` method:
+
+```js
+var terms = getInstance( "HyperClient@cbElasticsearch" )
+            .getTermsEnum( "hotels", {
+                "field" : "city",
+                "string" : "alb"
+            } );
+```
+
+You can ask for a larger rowset via `"size" : x` or even retrieve terms from multiple indices at once:
+
+```js
+var terms = getInstance( "HyperClient@cbElasticsearch" )
+            .getTermsEnum( ["cities","towns"], {
+                "field" : "name",
+                "string" : "west",
+                "size" : 50
+            } );
+```
+
+
 ## `SearchBuilder` Function Reference
 
 * `new([string index], [string type], [struct properties])` - Populates a new SearchBuilder object.

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -246,20 +246,24 @@ To retrieve this data, you can use the client's `getTermsEnum()` method:
 
 ```js
 var terms = getInstance( "HyperClient@cbElasticsearch" )
-            .getTermsEnum( "hotels", {
-                "field" : "city",
-                "string" : "alb"
-            } );
+            .getTermsEnum(
+                indexName  = "hotels",
+                field = "city",
+                match = "alb",
+                size = 50,
+                caseInsensitive = true
+            );
 ```
 
-You can ask for a larger rowset via `"size" : x` or even retrieve terms from multiple indices at once:
+For advanced lookups, you can use the second argument to pass a struct of custom options:
 
 ```js
 var terms = getInstance( "HyperClient@cbElasticsearch" )
             .getTermsEnum( ["cities","towns"], {
                 "field" : "name",
                 "string" : "west",
-                "size" : 50
+                "size" : 50,
+                "timeout" : "10s"
             } );
 ```
 

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -1675,4 +1675,22 @@ component accessors="true" threadSafe singleton {
 		return listGetAt( variables.versionTarget, 1, "." ) == versionNumber;
 	}
 
+	/**
+	 * Retrieve an enum of field terms from the index matching the provided string.
+	 *
+	 * @indexName string|array Index name or array of index names to query on
+	 * @opts struct Struct containing enum query options. "field" is required, "string" is recommended.
+	 * 
+	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-terms-enum.html
+	 */
+	function getTermsEnum( required indexName, required struct opts ){
+		if ( isArray( arguments.indexName ) ){ arguments.indexName = arrayToList( arguments.indexName ); }
+		var termsRequest = variables.nodePool.newRequest( "/#arguments.indexName#/_terms_enum", "post" );
+
+		return termsRequest
+				.setBody( arguments.opts )
+				.send()
+				.json();
+	}
+
 }

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -1679,16 +1679,23 @@ component accessors="true" threadSafe singleton {
 	 * Retrieve an enum of field terms from the index matching the provided string.
 	 *
 	 * @indexName string|array Index name or array of index names to query on
-	 * @opts struct Struct containing enum query options. "field" is required, "string" is recommended.
+	 * @field string|struct If string, field name to query. Otherwise, a struct of query options where only "field" is required.
 	 * 
 	 * @see https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-terms-enum.html
 	 */
-	function getTermsEnum( required indexName, required struct opts ){
+	function getTermsEnum( required indexName, required any field, any match, numeric size = 10, boolean caseInsensitive = true ){
 		if ( isArray( arguments.indexName ) ){ arguments.indexName = arrayToList( arguments.indexName ); }
 		var termsRequest = variables.nodePool.newRequest( "/#arguments.indexName#/_terms_enum", "post" );
 
+		var opts = {
+			"size"            : arguments.size,
+			"case_insensitive": arguments.caseInsensitive,
+			"field"           : !isNull( arguments.match ) ? arguments.match : javaCast( "null", 0 )
+		};
+		if ( !isSimpleValue( arguments.field ) ){ opts = arguments.field; }
+
 		return termsRequest
-				.setBody( arguments.opts )
+				.setBody( opts )
 				.send()
 				.json();
 	}

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -928,7 +928,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 			} );
 
-			describe( "Post index creation tests", function(){
+			xdescribe( "Post index creation tests", function(){
 				afterEach( function(){
 					// we give ourselves a few seconds before each next test for updates to persist
 					sleep( 500 );
@@ -1149,7 +1149,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			});
 
-			describe( "tasks", function(){
+			xdescribe( "tasks", function(){
 				it( "can retrieve all tasks on the cluster", function(){
 					var activeTasks = variables.model.getTasks();
 					expect( activeTasks ).toBeArray();
@@ -1210,7 +1210,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			} );
 
-			describe( "pipelines", function(){
+			xdescribe( "pipelines", function(){
 				beforeEach( function(){
 					variables.testPipeline = getWirebox()
 						.getInstance( "Pipeline@cbelasticsearch" )
@@ -1297,7 +1297,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			} );
 
-			describe( "ILM policies", function(){
+			xdescribe( "ILM policies", function(){
 				beforeEach( function(){
 					variables.testPolicyName = "es-client-test-policy";
 					variables.testPolicy = {
@@ -1345,7 +1345,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			});
 
-			describe( "Snapshot Repositories", function(){
+			xdescribe( "Snapshot Repositories", function(){
 				beforeEach( function(){
 					variables.testSnapshotName = "my-snapshot-repository";
 				});
@@ -1621,12 +1621,25 @@ component extends="coldbox.system.testing.BaseTestCase" {
 			} );
 
 			describe( "General requests", function() {
-				it( "can query terms enum", function() {
+				it( "can query terms enum with options struct", function() {
 					var result = getInstance( "HyperClient@cbElasticsearch" )
 						.getTermsEnum( [ variables.testIndexName ], {
 							"field" : "title",
 							"size" : 50
 						} );
+						expect( result ).toBeStruct()
+										.toHaveKey( "terms" )
+										.toHaveKey( "_shards" );
+				});
+				it( "can query terms enum with simple arguments", function() {
+					var result = getInstance( "HyperClient@cbElasticsearch" )
+						.getTermsEnum(
+							indexName  = variables.testIndexName,
+							field = "title",
+							match = "doc",
+							size = 50,
+							caseInsensitive = false
+						);
 						expect( result ).toBeStruct()
 										.toHaveKey( "terms" )
 										.toHaveKey( "_shards" );

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -928,7 +928,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 
 			} );
 
-			xdescribe( "Post index creation tests", function(){
+			describe( "Post index creation tests", function(){
 				afterEach( function(){
 					// we give ourselves a few seconds before each next test for updates to persist
 					sleep( 500 );
@@ -1149,7 +1149,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			});
 
-			xdescribe( "tasks", function(){
+			describe( "tasks", function(){
 				it( "can retrieve all tasks on the cluster", function(){
 					var activeTasks = variables.model.getTasks();
 					expect( activeTasks ).toBeArray();
@@ -1210,7 +1210,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			} );
 
-			xdescribe( "pipelines", function(){
+			describe( "pipelines", function(){
 				beforeEach( function(){
 					variables.testPipeline = getWirebox()
 						.getInstance( "Pipeline@cbelasticsearch" )
@@ -1297,7 +1297,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			} );
 
-			xdescribe( "ILM policies", function(){
+			describe( "ILM policies", function(){
 				beforeEach( function(){
 					variables.testPolicyName = "es-client-test-policy";
 					variables.testPolicy = {
@@ -1345,7 +1345,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 			});
 
-			xdescribe( "Snapshot Repositories", function(){
+			describe( "Snapshot Repositories", function(){
 				beforeEach( function(){
 					variables.testSnapshotName = "my-snapshot-repository";
 				});

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -1619,6 +1619,19 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} );
 
 			} );
+
+			describe( "General requests", function() {
+				it( "can query terms enum", function() {
+					var result = getInstance( "HyperClient@cbElasticsearch" )
+						.getTermsEnum( [ variables.testIndexName ], {
+							"field" : "title",
+							"size" : 50
+						} );
+						expect( result ).toBeStruct()
+										.toHaveKey( "terms" )
+										.toHaveKey( "_shards" );
+				});
+			});
 		} );
 	}
 


### PR DESCRIPTION
Add support for a terms enum retrieval:

```js
var terms = getInstance( "HyperClient@cbElasticsearch" )
            .getTermsEnum( "hotels", {
                "field" : "city",
                "string" : "alb"
            } );
```

https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-terms-enum.html

- [x] Added `hyperClient.getTermsEnum()` 🚀
- [x] Added docs 📖
- [x] Added tests 🤖