### PR TITLE
📦 NEW: Add generic setter for body params

### DIFF
--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -226,6 +226,26 @@ var docCount = getInstance( "SearchBuilder@cbElasticsearch" )
     .count();
 ```
 
+## Advanced Search Syntax
+
+Elasticsearch offers many, many features and functionalities. While the SearchBuilder *may* not provide a setter method for every search option, you can still use the `.param()` and `.set()` methods to set [query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-query-params) and [body parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-request-body), respectively.
+
+```js
+var response = getInstance( "SearchBuilder@cbElasticsearch" )
+    .new( "bookshop" )
+    .sort( "publishDate DESC" )
+    // match everything
+    .setQuery( { "match_all": {} } )
+    // Query parameter: return the document version with each hit
+    .param( "version", true )
+    // Body parameter: return a relevance score for each document, despite our custom sort
+    .set( "track_scores", true );
+    // Body parameter: filter by minimum relevance score
+	.set( "min_score", 3 )
+    // run the search
+    .execute();
+```
+
 ## Highlights
 
 ElasticSearch has the ability to highlight the portion of a document that matched. This is useful for showing context on why certain search results were returned. You can add an ElasticSearch highlight struct to your `SearchBuilder` using the `highlight` method. The struct should take the shape outlined on the [ElasticSearch website](https://www.elastic.co/guide/en/elasticsearch/reference/7.6/search-request-body.html#request-body-search-highlighting).

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -154,6 +154,24 @@ var search = getInstance( "SearchBuilder@cbElasticsearch" )
     .execute();
 ```
 
+After instantion, you can use the `.param()` and `.bodyParam()` methods to set [query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-query-params) and [body parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-request-body), respectively.
+
+```js
+var response = getInstance( "SearchBuilder@cbElasticsearch" )
+    .new( "bookshop" )
+    .sort( "publishDate DESC" )
+    // match everything
+    .setQuery( { "match_all": {} } )
+    // Query parameter: return the document version with each hit
+    .param( "version", true )
+    // Body parameter: return a relevance score for each document, despite our custom sort
+    .bodyParam( "track_scores", true );
+    // Body parameter: filter by minimum relevance score
+	.bodyParam( "min_score", 3 )
+    // run the search
+    .execute();
+```
+
 {% hint style="info" %}
 For more information on Elasticsearch query DSL, the [Search in Depth Documentation](https://www.elastic.co/guide/en/elasticsearch/guide/current/search-in-depth.html) is an excellent starting point.
 {% endhint %}
@@ -224,26 +242,6 @@ var docCount = getInstance( "SearchBuilder@cbElasticsearch" )
         }
     )
     .count();
-```
-
-## Advanced Search Syntax
-
-Elasticsearch offers many, many features and functionalities. While the SearchBuilder *may* not provide a setter method for every search option, you can still use the `.param()` and `.set()` methods to set [query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-query-params) and [body parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-request-body), respectively.
-
-```js
-var response = getInstance( "SearchBuilder@cbElasticsearch" )
-    .new( "bookshop" )
-    .sort( "publishDate DESC" )
-    // match everything
-    .setQuery( { "match_all": {} } )
-    // Query parameter: return the document version with each hit
-    .param( "version", true )
-    // Body parameter: return a relevance score for each document, despite our custom sort
-    .set( "track_scores", true );
-    // Body parameter: filter by minimum relevance score
-	.set( "min_score", 3 )
-    // run the search
-    .execute();
 ```
 
 ## Highlights

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -837,11 +837,13 @@ component accessors="true" {
 	}
 
 	/**
-	 * Adds a body parameter to the request (such as filtering by min_score, forcing a relevance score return, etc.)
+	 * Generic setter for any/all request properties.
+	 * 
+	 * For example, `set( "size", 100 )` or `set( "min_score" : 1 )`.
 	 * 
 	 * Example https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-request-body
 	 *
-	 * @name  the name of the body parameter to set
+	 * @name  the name of the parameter to set.
 	 * @value  the value of the parameter
 	 */
 	SearchBuilder function set( required string name, required any value ){
@@ -851,6 +853,19 @@ component accessors="true" {
 			variables.body[ arguments.name ] = arguments.value;
 		}
 
+		return this;
+	}
+
+	/**
+	 * Adds a body parameter to the request (such as filtering by min_score, forcing a relevance score return, etc.)
+	 * 
+	 * Example https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-request-body
+	 *
+	 * @name  the name of the body parameter to set
+	 * @value  the value of the parameter
+	 */
+	SearchBuilder function bodyParam( required string name, required any value ){
+		set( arguments.name, arguments.value );
 		return this;
 	}
 
@@ -1151,9 +1166,7 @@ component accessors="true" {
 			dsl[ "script" ] = variables.script;
 		}
 
-		if ( !isNull( variables.body ) && !structIsEmpty( variables.body ) ){
-			structAppend( dsl, variables.body, true );
-		}
+		structAppend( dsl, variables.body, true );
 
 		if ( !isNull( variables.sorting ) ) {
 			// we used a linked hashmap for sorting to maintain order

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -61,6 +61,11 @@ component accessors="true" {
 	property name="params";
 
 	/**
+	 * Body parameters which will be passed to transform the execution output
+	 */
+	property name="body" type="struct";
+
+	/**
 	 * Whether to preflight the query prior to execution( recommended ) - ensures consistent formatting to prevent errors
 	 **/
 	property name="preflight" type="boolean";
@@ -102,6 +107,7 @@ component accessors="true" {
 		variables.highlight = {};
 		variables.suggest   = {};
 		variables.params    = [];
+		variables.body      = {};
 
 		variables.maxRows  = 25;
 		variables.startRow = 0;
@@ -831,6 +837,24 @@ component accessors="true" {
 	}
 
 	/**
+	 * Adds a body parameter to the request (such as filtering by min_score, forcing a relevance score return, etc.)
+	 * 
+	 * Example https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-request-body
+	 *
+	 * @name  the name of the body parameter to set
+	 * @value  the value of the parameter
+	 */
+	SearchBuilder function set( required string name, required any value ){
+		if( variables.keyExists( arguments.name ) ){ 
+			variables[ arguments.name ] = arguments.value;
+		} else {
+			variables.body[ arguments.name ] = arguments.value;
+		}
+
+		return this;
+	}
+
+	/**
 	 * Adds highlighting to search
 	 *
 	 * https://www.elastic.co/guide/en/elasticsearch/reference/6.7/search-request-highlighting.html
@@ -1125,6 +1149,10 @@ component accessors="true" {
 
 		if ( !isNull( variables.script ) ) {
 			dsl[ "script" ] = variables.script;
+		}
+
+		if ( !isNull( variables.body ) && !structIsEmpty( variables.body ) ){
+			structAppend( dsl, variables.body, true );
 		}
 
 		if ( !isNull( variables.sorting ) ) {

--- a/test-harness/tests/specs/unit/SearchBuilderTest.cfc
+++ b/test-harness/tests/specs/unit/SearchBuilderTest.cfc
@@ -758,9 +758,25 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.getDSL()[ "_source" ][ "excludes" ] ).toBe( [ "*.description" ] );
 			} );
 
-			it( "Tests the generic set() method with root dsl", function(){
+			it( "Tests bodyParam() method for root dsl", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
 
+				searchBuilder.bodyParam( "explain", true );
+				searchBuilder.bodyParam( "post_filter", { 
+					"term": { "color": "red" }
+				} );
+
+				expect( searchBuilder.getDSL() ).toBeStruct();
+				expect( searchBuilder.getDSL() ).toHaveKey( "explain" );
+				expect( searchBuilder.getDSL().explain ).toBeTrue( "supports booleans in root DSL" );
+				expect( searchBuilder.getDSL() ).toHaveKey( "post_filter" );
+				expect( searchBuilder.getDSL().post_filter ).toBeStruct( "supports structs in root DSL" );
+			} );
+
+			it( "Tests bodyParam() and set() methods for root dsl", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+
+				searchBuilder.set( "min_score", 3 );
 				searchBuilder.set( "track_scores", true );
 				searchBuilder.set( "min_score", 3 );
 				searchBuilder.set( "docvalue_fields", [

--- a/test-harness/tests/specs/unit/SearchBuilderTest.cfc
+++ b/test-harness/tests/specs/unit/SearchBuilderTest.cfc
@@ -758,6 +758,30 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.getDSL()[ "_source" ][ "excludes" ] ).toBe( [ "*.description" ] );
 			} );
 
+			it( "Tests the generic set() method with root dsl", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+
+				searchBuilder.set( "track_scores", true );
+				searchBuilder.set( "min_score", 3 );
+				searchBuilder.set( "docvalue_fields", [
+					"user.id",
+					"http.response.*", 
+					{
+						"field": "date",
+						"format": "epoch_millis" 
+					}
+				] );
+
+				expect( searchBuilder.getDSL() ).toBeStruct();
+				expect( searchBuilder.getDSL() ).toHaveKey( "track_scores" );
+				expect( searchBuilder.getDSL().track_scores ).toBeTrue( "supports booleans in root DSL" );
+				expect( searchBuilder.getDSL() ).toHaveKey( "min_score" );
+				expect( searchBuilder.getDSL().min_score ).toBe( 3, "supports numeric value in root DSL" );
+				expect( searchBuilder.getDSL() ).toHaveKey( "docvalue_fields" );
+				expect( searchBuilder.getDSL().docvalue_fields ).toBeArray( "supports array value in root DSL");
+
+			});
+
 			it( "Tests the both the setSourceIncludes() and setSourceExcludes() methods", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
 


### PR DESCRIPTION
This allows the setting of previously unsupported Elasticsearch search options, such as `track_scores` or the `min_score` filter.

```js
var response = getInstance( "SearchBuilder@cbElasticsearch" )
    .new( "bookshop" )
    .sort( "publishDate DESC" )
    // match everything
    .setQuery( { "match_all": {} } )
    // Query parameter: return the document version with each hit
    .param( "version", true )
    // Body parameter: return a relevance score for each document, despite our custom sort
    .set( "track_scores", true );
    // Body parameter: filter by minimum relevance score
    .set( "min_score", 3 )
    // run the search
    .execute();
```

- [x] Adds `.set()` for body params 🚀
- [x] Adds test for `.set()` syntax 🤖
- [x] Adds docs for `.set()` and `.param()` methods 📖