### PR TITLE
👌 IMPROVE: Rename startRow/maxRows to from/size, respectively.

### DIFF
--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -121,6 +121,25 @@ searchBuilder.sort( "author.age", "DESC" );
 For more information on sorting search results, check out [Elasticsearch: Sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/sort-search-results.html#sort-search-results)
 {% endhint %}
 
+### Paging Through Query Results
+
+The `size` and `from` search options allow adjusting the page size and start row, respectively, of the configured search:
+
+```js
+searchBuilder.setFrom( 11 );
+searchBuilder.setSize( 10 );
+```
+
+The number of matched documents will be in the `SearchResult`'s `getHitCount()` value:
+
+```js
+var totalRows = result.getHitCount();
+```
+
+{% hint style="info" %}
+Be sure to read the [Elasticsearch "Paginate Search Results" documentation](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/paginate-search-results.html), as paging too deeply can adversely affect CPU and memory usage.
+{% endhint %}
+
 ### Advanced Query DSL
 
 The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing full configuration of your search queries. There are several methods to provide the raw query language to the Search Builder. One is during instantiation.

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -75,8 +75,8 @@ component accessors="true" {
 	property name="suggest";
 
 	// Optional search defaults
-	property name="maxRows";
-	property name="startRow";
+	property name="size";
+	property name="from";
 
 
 	function onDIComplete(){
@@ -103,8 +103,8 @@ component accessors="true" {
 		variables.suggest   = {};
 		variables.params    = [];
 
-		variables.maxRows  = 25;
-		variables.startRow = 0;
+		variables.size  = 25;
+		variables.from = 0;
 
 		variables.preflight = true;
 
@@ -150,6 +150,24 @@ component accessors="true" {
 		return getClient().deleteByQuery( this );
 	}
 
+	/**
+	 * !DEPRECATED - Backwards compatible setter for max result size
+	 * 
+	 * @value Max number of records to retrieve.
+	 */
+	SearchBuilder function setMaxRows( required numeric value ){
+		variables.size = arguments.value;
+		return this;
+	}
+	/**
+	 * !DEPRECATED - Backwards compatible setter for result start offset
+	 * 
+	 * @value Starting document offset.
+	 */
+	SearchBuilder function setStartRow( required numeric value ){
+		variables.from = arguments.value;
+		return this;
+	}
 
 	/**
 	 * Populates a new SearchBuilder object
@@ -171,13 +189,15 @@ component accessors="true" {
 		if ( !isNull( arguments.properties ) ) {
 			for ( var propName in arguments.properties ) {
 				switch ( propName ) {
+					case "from":
 					case "offset":
 					case "startRow": {
-						variables.startRow = arguments.properties[ propName ];
+						variables.from = arguments.properties[ propName ];
 						break;
 					}
+					case "size":
 					case "maxRows": {
-						variables.maxRows = arguments.properties[ propName ];
+						variables.size = arguments.properties[ propName ];
 						break;
 					}
 					case "query": {
@@ -1099,8 +1119,8 @@ component accessors="true" {
 
 		if ( !isNull( variables.query ) && !structIsEmpty( variables.query ) ) {
 			dsl[ "query" ] = variables.query;
-			dsl[ "from" ]  = variables.startRow;
-			dsl[ "size" ]  = variables.maxRows;
+			dsl[ "from" ]  = variables.from;
+			dsl[ "size" ]  = variables.size;
 		}
 
 		if ( !isNull( variables.highlight ) && !structIsEmpty( variables.highlight ) ) {

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -151,7 +151,9 @@ component accessors="true" {
 	}
 
 	/**
-	 * !DEPRECATED - Backwards compatible setter for max result size
+	 * Backwards compatible setter for max result size
+	 * 
+	 * @deprecated
 	 * 
 	 * @value Max number of records to retrieve.
 	 */
@@ -160,7 +162,9 @@ component accessors="true" {
 		return this;
 	}
 	/**
-	 * !DEPRECATED - Backwards compatible setter for result start offset
+	 * Backwards compatible setter for result start offset
+	 * 
+	 * @deprecated
 	 * 
 	 * @value Starting document offset.
 	 */

--- a/models/migrations/Manager.cfc
+++ b/models/migrations/Manager.cfc
@@ -71,7 +71,7 @@ component {
 		searchBuilder
 			.setQuery( { "match_all" : {} } )
 			.setSourceIncludes( [ "name", "migrationRan" ] )
-			.setMaxRows( searchBuilder.count() )
+			.setSize( searchBuilder.count() )
 			.sort( "migrationRan desc" );
 		return searchBuilder
 			.execute()

--- a/test-harness/tests/specs/unit/SearchBuilderTest.cfc
+++ b/test-harness/tests/specs/unit/SearchBuilderTest.cfc
@@ -788,11 +788,41 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
 			} );
 
+			it( "Tests the pagination size/from via .new() properties", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs", {
+					size : 15,
+					from : 16
+				} );
+				searchBuilder.setQuery( { "match_all": {} } );
+				debug( searchBuilder.getDSL() );
+				expect( searchBuilder.getDSL() ).toBeStruct();
+				expect( searchBuilder.getDSL() ).toHaveKey( "from" );
+				expect( searchBuilder.getDSL() ).toHaveKey( "size" );
+				expect( searchBuilder.getDSL().from ).toBe( 16 );
+				expect( searchBuilder.getDSL().size ).toBe( 15 );
+
+				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
+			} );
+
 			it( "Tests pagination via setStartRow()/setMaxRows()", function(){
 				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
 				searchBuilder.setQuery( { "match_all": {} } );
 				searchBuilder.setStartRow( 51 );
 				searchBuilder.setMaxRows( 50 );
+
+				expect( searchBuilder.getDSL() ).toBeStruct();
+				expect( searchBuilder.getDSL() ).toHaveKey( "from" );
+				expect( searchBuilder.getDSL() ).toHaveKey( "size" );
+				expect( searchBuilder.getDSL().from ).toBe( 51 );
+				expect( searchBuilder.getDSL().size ).toBe( 50 );
+
+				expect( searchBuilder.execute() ).toBeInstanceOf( "cbElasticsearch.models.SearchResult" );
+			});
+			it( "Tests pagination via setFrom()/setSize()", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+				searchBuilder.setQuery( { "match_all": {} } );
+				searchBuilder.setFrom( 51 );
+				searchBuilder.setSize( 50 );
 
 				expect( searchBuilder.getDSL() ).toBeStruct();
 				expect( searchBuilder.getDSL() ).toHaveKey( "from" );


### PR DESCRIPTION
New syntax:

```js
searchBuilder.setFrom( 11 );
searchBuilder.setSize( 10 );
```

Still keeps backwards-compatible shims in place for the old parameter names:

```js
var searchBuilder = variables.model.new( variables.testIndexName, "testdocs", {
					maxRows : 15,
					startRow : 16
				} );
searchBuilder.setStartRow( 51 );
searchBuilder.setMaxRows( 50 );
```

- [x] Renames `startRow` to `from` 💪
- [x] Renames `maxRows` to `size` 🔨
- [x] Keeps support for older names in both `.new()` and setter methods 🎉
- [x] Adds test for new names 🤖
- [x] Adds pagination docs to `Search.md` 📖