### PR TITLE
📦 NEW: Add Term Vector endpoint support

### DIFF
--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -19,10 +19,10 @@ To output the results of our search, we would use a loop, accessing the `Documen
 
 ```js
 for( var resultDocument in searchResults.getHits() ){
-	var resultScore     = resultDocument.getScore();
-	var documentMemento = resultDocument.getMemento();
-	var bookName        = documentMemento.name;
-	var bookDescription = documentMemento.description;
+    var resultScore     = resultDocument.getScore();
+    var documentMemento = resultDocument.getMemento();
+    var bookName        = documentMemento.name;
+    var bookDescription = documentMemento.description;
 }
 ```
 
@@ -30,9 +30,9 @@ The "memento" is our structural representation of the document. We can also use 
 
 ```js
 for( var resultDocument in searchResults.getHits() ){
-	var resultScore     = resultDocument.getScore();
-	var bookName        = resultDocument.getValue( "name" );
-	var bookDescription = resultDoument.getValue( "description" );
+    var resultScore     = resultDocument.getScore();
+    var bookName        = resultDocument.getValue( "name" );
+    var bookDescription = resultDoument.getValue( "description" );
 }
 ```
 
@@ -249,7 +249,7 @@ var response = getInstance( "SearchBuilder@cbElasticsearch" )
     // Body parameter: return a relevance score for each document, despite our custom sort
     .bodyParam( "track_scores", true );
     // Body parameter: filter by minimum relevance score
-	.bodyParam( "min_score", 3 )
+    .bodyParam( "min_score", 3 )
     // run the search
     .execute();
 ```
@@ -367,6 +367,49 @@ var terms = getInstance( "HyperClient@cbElasticsearch" )
             } );
 ```
 
+## Term Vectors
+
+The ["Term Vectors" Elasticsearch API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html) allows you to retrieve information and statistics for terms in a specific document field. This could be useful for finding the most common term in a book description, or retrieving all terms with a minimum word length from the book title.
+
+### Retrieving Term Vectors By Document ID
+
+To retrieve term vectors for a known document ID:
+
+```js
+var result = variables.model.getTermVectors(
+    "books",
+    "book_12345",
+    { "fields" : "title" }
+);
+```
+
+Use the third argument, `params`, to configure the request using the [documented query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html#docs-termvectors-api-query-params): 
+
+```js
+var result = variables.model.getTermVectors(
+    indexName = "books",
+    id = "book_12345",
+    params = {
+        "fields" : "title",
+        "min_word_length" : 4
+    }
+);
+```
+
+### Retrieving Term Vectors By Payload
+
+If you wish to analyze a payload (not an existing document) you can pass a payload in the `body` argument's `"doc"` field:
+
+```js
+var result = variables.model.getTermVectors(
+    indexName = "books",
+    body = {
+      "doc" : {
+        "title" : "The Lord of the Rings: The Fellowship of the Ring"
+      }
+    }
+);
+```
 
 ## `SearchBuilder` Function Reference
 

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -376,7 +376,7 @@ The ["Term Vectors" Elasticsearch API](https://www.elastic.co/guide/en/elasticse
 To retrieve term vectors for a known document ID:
 
 ```js
-var result = variables.model.getTermVectors(
+var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
     "books",
     "book_12345",
     { "fields" : "title" }
@@ -386,7 +386,7 @@ var result = variables.model.getTermVectors(
 Use the third argument, `params`, to configure the request using the [documented query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html#docs-termvectors-api-query-params): 
 
 ```js
-var result = variables.model.getTermVectors(
+var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
     indexName = "books",
     id = "book_12345",
     params = {
@@ -401,7 +401,7 @@ var result = variables.model.getTermVectors(
 If you wish to analyze a payload (not an existing document) you can pass a payload in the `body` argument's `"doc"` field:
 
 ```js
-var result = variables.model.getTermVectors(
+var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
     indexName = "books",
     body = {
       "doc" : {
@@ -410,6 +410,39 @@ var result = variables.model.getTermVectors(
     }
 );
 ```
+
+### SearchBuilder Term Vector Fetch
+
+The SearchBuilder object also offers a `getTermVectors()` method with a more fluent argument syntax:
+
+```js
+var result = getInstance( "SearchBuilder@cbElasticsearch" )
+                .new( "books" )
+                .getTermVectors(
+                    myDocument._id,
+                    "title,author.name"
+                );
+```
+
+or pass a struct of options for more fine-grained term vector retrieval:
+
+```js
+var result = getInstance( "SearchBuilder@cbElasticsearch" )
+                .new( "books" )
+                .getTermVectors(
+                    myDocument._id,
+                    "title,author.name",
+                    {
+                        "field_statistics" : false,
+                        "payloads" : false,
+                        "filter" : {
+                            "min_term_freq": 1,
+                            "min_word_length" : "4"
+                        }
+                    }
+                );
+```
+
 
 ## `SearchBuilder` Function Reference
 

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -373,37 +373,40 @@ The ["Term Vectors" Elasticsearch API](https://www.elastic.co/guide/en/elasticse
 
 ### Retrieving Term Vectors By Document ID
 
-To retrieve term vectors for a known document ID:
+To retrieve term vectors for a known document ID, pass the index name, id, and an array or list of fields to pull from:
 
 ```js
 var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
     "books",
     "book_12345",
-    { "fields" : "title" }
+    [ "title" ]
 );
 ```
 
-Use the third argument, `params`, to configure the request using the [documented query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html#docs-termvectors-api-query-params): 
+You can fine-tune the request using the `options` argument:
 
 ```js
 var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
     indexName = "books",
     id = "book_12345",
-    params = {
+    options = {
         "fields" : "title",
         "min_word_length" : 4
     }
 );
 ```
 
+See the [query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-termvectors.html#docs-termvectors-api-query-params) documentation for more configuration options.
+
 ### Retrieving Term Vectors By Payload
 
-If you wish to analyze a payload (not an existing document) you can pass a payload in the `body` argument's `"doc"` field:
+If you wish to analyze a payload (not an existing document) you can pass a `"doc"` payload in the `options` argument:
 
 ```js
 var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
     indexName = "books",
-    body = {
+    fields = [ "title" ],
+    options = {
       "doc" : {
         "title" : "The Lord of the Rings: The Fellowship of the Ring"
       }
@@ -413,36 +416,16 @@ var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
 
 ### SearchBuilder Term Vector Fetch
 
-The SearchBuilder object also offers a `getTermVectors()` method with a more fluent argument syntax:
+The SearchBuilder object also offers a `getTermVectors()` method for convenience:
 
 ```js
 var result = getInstance( "SearchBuilder@cbElasticsearch" )
                 .new( "books" )
                 .getTermVectors(
                     myDocument._id,
-                    "title,author.name"
+                    [ "title,author.name" ]
                 );
 ```
-
-or pass a struct of options for more fine-grained term vector retrieval:
-
-```js
-var result = getInstance( "SearchBuilder@cbElasticsearch" )
-                .new( "books" )
-                .getTermVectors(
-                    myDocument._id,
-                    "title,author.name",
-                    {
-                        "field_statistics" : false,
-                        "payloads" : false,
-                        "filter" : {
-                            "min_term_freq": 1,
-                            "min_word_length" : "4"
-                        }
-                    }
-                );
-```
-
 
 ## `SearchBuilder` Function Reference
 

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -173,16 +173,20 @@ component accessors="true" {
 	/**
 	 * Request a vector of terms for the given index, document or document ID, and field names
 	 *
-	 * @params		struct		Struct of query parameters to influence the request. For example: `"offsets": false }`
-	 * @body		struct		Body payload to send. For example: `{ "filter": { "max_num_terms": 3 } }`
+	 * @id 		Primary key of a document to query term vectors on
+	 * @fields 	Array or list of fields to pull term vectors on
+	 * @options Any custom query or body parameters.
 	 */
-	struct function getTermVectors( string id = "", string fields = "", struct options = {} ){
+	struct function getTermVectors( string id = "", any fields = "", struct options = {} ){
 		var args = {
 			indexName = variables.index,
 			id        = arguments.id,
 			params    = arguments.options,
 			body      = {}
 		};
+		if ( isArray( arguments.fields ) ) {
+			arguments.fields = arrayToList( arguments.fields );
+		}
 		arguments.options[ "fields" ] = arguments.fields;
 		if ( arguments.options.keyExists( "doc" ) ){
 			args.body[ "doc" ] = arguments.options.doc;

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -171,6 +171,31 @@ component accessors="true" {
 	}
 
 	/**
+	 * Request a vector of terms for the given index, document or document ID, and field names
+	 *
+	 * @params		struct		Struct of query parameters to influence the request. For example: `"offsets": false }`
+	 * @body		struct		Body payload to send. For example: `{ "filter": { "max_num_terms": 3 } }`
+	 */
+	struct function getTermVectors( string id = "", string fields = "", struct options = {} ){
+		var args = {
+			indexName = variables.index,
+			id        = arguments.id,
+			params    = arguments.options,
+			body      = {}
+		};
+		arguments.options[ "fields" ] = arguments.fields;
+		if ( arguments.options.keyExists( "doc" ) ){
+			args.body[ "doc" ] = arguments.options.doc;
+			arguments.options.delete( "doc" );
+		}
+		if ( arguments.options.keyExists( "filter" ) ){
+			args.body[ "filter" ] = arguments.options.filter;
+			arguments.options.delete( "filter" );
+		}
+		return getClient().getTermVectors( argumentCollection = args );
+	}
+
+	/**
 	 * Backwards compatible setter for max result size
 	 *
 	 * @deprecated

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -175,27 +175,20 @@ component accessors="true" {
 	 *
 	 * @id 		Primary key of a document to query term vectors on
 	 * @fields 	Array or list of fields to pull term vectors on
-	 * @options Any custom query or body parameters.
+	 * @options Any custom parameters to send with the request.
 	 */
 	struct function getTermVectors( string id = "", any fields = "", struct options = {} ){
+		if ( !isArray( arguments.fields ) ) {
+			arguments.fields = listToArray( arguments.fields );
+		}
 		var args = {
 			indexName = variables.index,
 			id        = arguments.id,
-			params    = arguments.options,
-			body      = {}
+			params    = {},
+			body      = arguments.options
 		};
-		if ( isArray( arguments.fields ) ) {
-			arguments.fields = arrayToList( arguments.fields );
-		}
-		arguments.options[ "fields" ] = arguments.fields;
-		if ( arguments.options.keyExists( "doc" ) ){
-			args.body[ "doc" ] = arguments.options.doc;
-			arguments.options.delete( "doc" );
-		}
-		if ( arguments.options.keyExists( "filter" ) ){
-			args.body[ "filter" ] = arguments.options.filter;
-			arguments.options.delete( "filter" );
-		}
+		args.body[ "fields" ] = arguments.fields;
+
 		return getClient().getTermVectors( argumentCollection = args );
 	}
 

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -178,16 +178,8 @@ component accessors="true" {
 	 * @options Any custom parameters to send with the request.
 	 */
 	struct function getTermVectors( string id = "", any fields = "", struct options = {} ){
-		if ( !isArray( arguments.fields ) ) {
-			arguments.fields = listToArray( arguments.fields );
-		}
-		var args = {
-			indexName = variables.index,
-			id        = arguments.id,
-			params    = {},
-			body      = arguments.options
-		};
-		args.body[ "fields" ] = arguments.fields;
+		var args = arguments;
+		args.indexName = variables.index;
 
 		return getClient().getTermVectors( argumentCollection = args );
 	}

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -536,9 +536,14 @@ component accessors="true" threadSafe singleton {
 	 * @indexName 	string		Index name or alias.
 	 * @id			string		Document ID to query term vectors on.
 	 * @params		struct		Struct of query parameters to influence the request. For example: `"offsets": false }`
-	 * @body		struct		Body payload to send. For example: `{ "filter": { "max_num_terms": 3 } }`
+	 * @options		struct		Body payload to send. For example: `{ "filter": { "max_num_terms": 3 } }`
 	 */
-	struct function getTermVectors( required string indexName, string id = "", struct params = {}, struct body = {} ){
+	struct function getTermVectors( required string indexName, string id = "", any fields = [], struct options = {} ){
+		arguments.options[ "fields" ] = arguments.fields;
+		if ( !isArray( arguments.options["fields"] ) ) {
+			arguments.options["fields"] = listToArray( arguments.options["fields"] );
+		}
+
 		var endpoint = [arguments.indexName, "_termvectors" ];
 		if ( arguments.id != "" ) {
 			endpoint.append( arguments.id );
@@ -546,8 +551,7 @@ component accessors="true" threadSafe singleton {
 		var vectorRequest = variables.nodePool.newRequest( arrayToList( endpoint, "/" ), "POST" );
 
 		return vectorRequest
-			.setBody( getUtil().toJSON( arguments.body ) )
-			.withQueryParams( arguments.params )
+			.setBody( getUtil().toJSON( arguments.options ) )
 			.send()
 			.json();
 	}

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -531,6 +531,27 @@ component accessors="true" threadSafe singleton {
 	}
 
 	/**
+	 * Request a vector of terms for the given index, document or document ID, and field names
+	 *
+	 * @indexName 	string		Index name or alias.
+	 * @params		struct		Struct of query parameters to influence the request. For example: `"offsets": false }`
+	 * @body		struct		Body payload to send. For example: `{ "filter": { "max_num_terms": 3 } }`
+	 */
+	struct function getTermVectors( required string indexName, string id = "", struct params = {}, struct body = {} ){
+		var endpoint = [arguments.indexName, "_termvectors" ];
+		if ( arguments.id != "" ) {
+			endpoint.append( arguments.id );
+		}
+		var vectorRequest = variables.nodePool.newRequest( arrayToList( endpoint, "/" ), "GET" );
+
+		return vectorRequest
+			.setBody( getUtil().toJSON( arguments.body ) )
+			.withQueryParams( arguments.params )
+			.send()
+			.json();
+	}
+
+	/**
 	 * Returns a struct containing all indices in the system, with statistics
 	 *
 	 * @verbose 	boolean 	whether to return the full stats output for the index

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -542,7 +542,7 @@ component accessors="true" threadSafe singleton {
 		if ( arguments.id != "" ) {
 			endpoint.append( arguments.id );
 		}
-		var vectorRequest = variables.nodePool.newRequest( arrayToList( endpoint, "/" ), "GET" );
+		var vectorRequest = variables.nodePool.newRequest( arrayToList( endpoint, "/" ), "POST" );
 
 		return vectorRequest
 			.setBody( getUtil().toJSON( arguments.body ) )

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -534,6 +534,7 @@ component accessors="true" threadSafe singleton {
 	 * Request a vector of terms for the given index, document or document ID, and field names
 	 *
 	 * @indexName 	string		Index name or alias.
+	 * @id			string		Document ID to query term vectors on.
 	 * @params		struct		Struct of query parameters to influence the request. For example: `"offsets": false }`
 	 * @body		struct		Body payload to send. For example: `{ "filter": { "max_num_terms": 3 } }`
 	 */

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -1028,9 +1028,9 @@ component extends="coldbox.system.testing.BaseTestCase" {
 						var result = variables.model.getTermVectors(
 							variables.testIndexName,
 							testDocument._id,
-							{ "fields" : "title" }
+							"title"
 						);
-
+debug( result );
 						expect( result.keyExists( "error" ) ).toBeFalse();
 						expect( result.keyExists( "term_vectors" ) ).toBeTrue();
 						expect( result.term_vectors ).toHaveKey( "title" );
@@ -1044,7 +1044,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 						// test options
 						var result = variables.model.getTermVectors(
 							indexName = variables.testIndexName,
-							body = {
+							options = {
 								"doc" : {
 									"title" : "My test document"
 								},

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -1031,8 +1031,8 @@ component extends="coldbox.system.testing.BaseTestCase" {
 							{ "fields" : "title" }
 						);
 
-						expect( result.keyExists( "term_vectors" ) ).toBeTrue();
 						expect( result.keyExists( "error" ) ).toBeFalse();
+						expect( result.keyExists( "term_vectors" ) ).toBeTrue();
 						expect( result.term_vectors ).toHaveKey( "title" );
 						expect( result.term_vectors.title ).toBeStruct()
 															.toHaveKey( "field_statistics" )

--- a/test-harness/tests/specs/unit/HyperClientTest.cfc
+++ b/test-harness/tests/specs/unit/HyperClientTest.cfc
@@ -1007,6 +1007,63 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					expect( refreshResult._shards.total ).toBe( 0 );
 				} );
 
+				describe( "termVectors", function() {
+					it( "can get term vectors by document ID", function() {
+						expect( variables ).toHaveKey( "testIndexName" );
+
+						// create document and save
+						var testDocument = {
+							"_id"         : createUUID(),
+							"title"       : "My Test Document",
+							"createdTime" : dateTimeFormat( now(), "yyyy-mm-dd'T'hh:nn:ssZZ" )
+						};
+
+						var document = getWirebox()
+							.getInstance( "Document@cbElasticsearch" )
+							.new(
+								variables.testIndexName,
+								"_doc",
+								testDocument
+							).save( refresh = true );
+						var result = variables.model.getTermVectors(
+							variables.testIndexName,
+							testDocument._id,
+							{ "fields" : "title" }
+						);
+
+						expect( result.keyExists( "term_vectors" ) ).toBeTrue();
+						expect( result.keyExists( "error" ) ).toBeFalse();
+						expect( result.term_vectors ).toHaveKey( "title" );
+						expect( result.term_vectors.title ).toBeStruct()
+															.toHaveKey( "field_statistics" )
+															.toHaveKey( "terms" );
+					});
+					it( "can get term vectors by doc payload", function(){
+						expect( variables ).toHaveKey( "testIndexName" );
+	
+						// test options
+						var result = variables.model.getTermVectors(
+							indexName = variables.testIndexName,
+							body = {
+								"doc" : {
+									"title" : "My test document"
+								},
+								"filter" : {
+									"min_word_length" : 3
+								}
+							}
+						);
+	
+						expect( result.keyExists( "error" ) ).toBeFalse();
+						expect( result ).toHaveKey( "term_vectors" );
+	
+						// ensure only short terms returned
+						expect( result.term_vectors.title.terms )
+									.toHaveKey( "document" )
+									.notToHaveKey( "my" );
+					} );
+				});
+
 				it( "Tests getIndexStats method ", function(){
 					expect( variables ).toHaveKey( "testIndexName" );
 

--- a/test-harness/tests/specs/unit/SearchBuilderTest.cfc
+++ b/test-harness/tests/specs/unit/SearchBuilderTest.cfc
@@ -1312,6 +1312,7 @@ component extends="coldbox.system.testing.BaseTestCase" {
 					var result = variables.model
 						.new( variables.testIndexName )
 						.getTermVectors(
+							fields = [ "title" ],
 							options = {
 								"field_statistics" : false,
 								"payloads" : false,


### PR DESCRIPTION
This adds support for Elasticsearch's "terms vector" API endpoint, which allows users to query for most common terms in specific document fields.

https://www.elastic.co/guide/en/elasticsearch/reference/8.7/docs-termvectors.html

```js
var result = variables.model.getTermVectors(
	"books",
	"book_12345",
	{ "fields" : "title" }
);
```

- [X] Adds `getTermVectors(indexName, id, params, body )` to `HyperClient.cfc` 📦
- [X] Adds test for term vectors by document ID  🤖
- [X] Adds test for term vectors by "artificial document" payload 🤖
- [X] Adds documentation for multiple usage scenarios 📖