### PR TITLE
🐛 FIX: Correct wrong type error when deleteByID() tries to delegate error handling to onResponseFailure

### DIFF
--- a/box.json
+++ b/box.json
@@ -2,7 +2,7 @@
     "name":"Elasticsearch for the Coldbox Framework",
     "author":"Ortus Solutions <info@ortussolutions.com",
     "location":"https://downloads.ortussolutions.com/ortussolutions/coldbox-modules/cbelasticsearch/@build.version@/cbelasticsearch-@build.version@+@build.number@.zip",
-    "version":"3.1.4",
+    "version":"3.2.0",
     "slug":"cbelasticsearch",
     "type":"modules",
     "homepage":"https://cbelasticsearch.ortusbooks.com",

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ----
 ## [Unreleased]
 
-## [3.1.3] - 06-08-2023
+## [3.2.0] - 06-08-2023
 ### Added
 * [Added `getTermVectors` to SearchBuilder and Client](https://cbelasticsearch.ortusbooks.com/searching/search#term-vectors) to allow for fetching term vectors on document field(s)
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ----
 ## [Unreleased]
 
+## [3.2.1] - 06-20-2023
+### Fixed
+* Corrected a typing error when performing error handling in `deleteById()`
+
 ## [3.2.0] - 06-08-2023
 ### Added
 * [Added `getTermVectors` to SearchBuilder and Client](https://cbelasticsearch.ortusbooks.com/searching/search#term-vectors) to allow for fetching term vectors on document field(s)

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -1031,10 +1031,11 @@ component accessors="true" threadSafe singleton {
 			deleteRequest.setQueryParam( param.name, param.value );
 		} );
 
-		var deleteResult = deleteRequest.send().json();
+		var response = deleteRequest.send();
+		var deleteResult = response.json();
 
 		if ( arguments.throwOnError && structKeyExists( deleteResult, "error" ) ) {
-			onResponseFailure( deleteResult );
+			onResponseFailure( response );
 		}
 
 		return deleteResult.keyExists( "error" ) ? false : deleteResult.result == "deleted";


### PR DESCRIPTION
This fixes this error message in `deleteById()` when `throwOnError=true` (which it is by default):

>  Invalid call of the function [onResponseFailure], first Argument [response] is of invalid type, Cannot cast Object type [Struct] to a value of type [Hyper.models.HyperResponse]