### PR TITLE
👌 IMPROVE: Add support for missing 'reason' key in error handlers

### DIFF
--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -177,8 +177,12 @@ component accessors="true" {
 	 * @fields 	Array or list of fields to pull term vectors on
 	 * @options Any custom parameters to send with the request.
 	 */
-	struct function getTermVectors( string id = "", any fields = "", struct options = {} ){
-		var args = arguments;
+	struct function getTermVectors(
+		string id      = "",
+		any fields     = "",
+		struct options = {}
+	){
+		var args       = arguments;
 		args.indexName = variables.index;
 
 		return getClient().getTermVectors( argumentCollection = args );
@@ -196,13 +200,13 @@ component accessors="true" {
 		return this;
 	}
 
-        /**
+	/**
 	 * Backwards compatible getter for max result size
-	 * 
+	 *
 	 * @deprecated
 	 */
 	any function getMaxRows(){
-	    return getSize();
+		return getSize();
 	}
 
 	/**
@@ -217,13 +221,13 @@ component accessors="true" {
 		return this;
 	}
 
-        /**
+	/**
 	 * Backwards compatible getter for start row
-	 * 
+	 *
 	 * @deprecated
 	 */
 	any function getStartRow(){
-	    return getFrom();
+		return getFrom();
 	}
 
 	/**

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -453,7 +453,7 @@ component accessors="true" threadSafe singleton {
 			} else if ( reindexResult.keyExists( "error" ) ) {
 				throw(
 					type         = "cbElasticsearch.HyperClient.ReindexFailedException",
-					message      = "The reindex action failed with response code [#reindexResult.status#].  The cause of this exception was #reindexResult.error.reason ?: 'None'#",
+					message      = "The reindex action failed with response code [#reindexResult.status#].  The cause of this exception was #reindexResult.error.reason ?: "None"#",
 					extendedInfo = getUtil().toJSON( reindexResult )
 				);
 			}
@@ -538,13 +538,18 @@ component accessors="true" threadSafe singleton {
 	 * @params		struct		Struct of query parameters to influence the request. For example: `"offsets": false }`
 	 * @options		struct		Body payload to send. For example: `{ "filter": { "max_num_terms": 3 } }`
 	 */
-	struct function getTermVectors( required string indexName, string id = "", any fields = [], struct options = {} ){
+	struct function getTermVectors(
+		required string indexName,
+		string id      = "",
+		any fields     = [],
+		struct options = {}
+	){
 		arguments.options[ "fields" ] = arguments.fields;
-		if ( !isArray( arguments.options["fields"] ) ) {
-			arguments.options["fields"] = listToArray( arguments.options["fields"] );
+		if ( !isArray( arguments.options[ "fields" ] ) ) {
+			arguments.options[ "fields" ] = listToArray( arguments.options[ "fields" ] );
 		}
 
-		var endpoint = [arguments.indexName, "_termvectors" ];
+		var endpoint = [ arguments.indexName, "_termvectors" ];
 		if ( arguments.id != "" ) {
 			endpoint.append( arguments.id );
 		}
@@ -1031,7 +1036,7 @@ component accessors="true" threadSafe singleton {
 			deleteRequest.setQueryParam( param.name, param.value );
 		} );
 
-		var response = deleteRequest.send();
+		var response     = deleteRequest.send();
 		var deleteResult = response.json();
 
 		if ( arguments.throwOnError && structKeyExists( deleteResult, "error" ) ) {
@@ -1206,10 +1211,12 @@ component accessors="true" threadSafe singleton {
 					item.update.keyExists( "error" )
 					&& item.update.error.keyExists( "root_cause" )
 				)
-				 ? " Reason: #isArray( item.update.error.root_cause ) ? ( item.update.error.root_cause[ 1 ].reason ?: 'None' ) : ( item.update.error.root_cause.reason ?: 'None' )#"
+				 ? " Reason: #isArray( item.update.error.root_cause ) ? ( item.update.error.root_cause[ 1 ].reason ?: "None" ) : (
+					item.update.error.root_cause.reason ?: "None"
+				)#"
 				 : (
 					structKeyExists( item.update, "error" )
-					 ? " Reason: #item.update.error.reason ?: 'None'#"
+					 ? " Reason: #item.update.error.reason ?: "None"#"
 					 : ""
 				);
 				throw(

--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -453,7 +453,7 @@ component accessors="true" threadSafe singleton {
 			} else if ( reindexResult.keyExists( "error" ) ) {
 				throw(
 					type         = "cbElasticsearch.HyperClient.ReindexFailedException",
-					message      = "The reindex action failed with response code [#reindexResult.status#].  The cause of this exception was #reindexResult.error.reason#",
+					message      = "The reindex action failed with response code [#reindexResult.status#].  The cause of this exception was #reindexResult.error.reason ?: 'None'#",
 					extendedInfo = getUtil().toJSON( reindexResult )
 				);
 			}
@@ -1206,10 +1206,10 @@ component accessors="true" threadSafe singleton {
 					item.update.keyExists( "error" )
 					&& item.update.error.keyExists( "root_cause" )
 				)
-				 ? " Reason: #isArray( item.update.error.root_cause ) ? item.update.error.root_cause[ 1 ].reason : item.update.error.root_cause.reason#"
+				 ? " Reason: #isArray( item.update.error.root_cause ) ? ( item.update.error.root_cause[ 1 ].reason ?: 'None' ) : ( item.update.error.root_cause.reason ?: 'None' )#"
 				 : (
 					structKeyExists( item.update, "error" )
-					 ? " Reason: #item.update.error.reason#"
+					 ? " Reason: #item.update.error.reason ?: 'None'#"
 					 : ""
 				);
 				throw(

--- a/models/logging/LogstashAppender.cfc
+++ b/models/logging/LogstashAppender.cfc
@@ -123,10 +123,10 @@ component
 	 * Runs on registration
 	 */
 	public LogstashAppender function onRegistration() output=false{
-		try{
+		try {
 			ensureDataStream();
 			variables._dataStreamAssured = true;
-		} catch( any e ){
+		} catch ( any e ) {
 			createObject( "java", "java.lang.System" ).err.println(
 				"Unable to create data stream. The attempt to communicate with the Elasticsearch server returned: #e.message# - #e.detail#.  Your ability to log messages with this appender may be compromised."
 			);
@@ -138,11 +138,10 @@ component
 	 * Write an entry into the appender.
 	 */
 	public void function logMessage( required any logEvent ) output=false{
-
-		if( !variables._dataStreamAssured ){
+		if ( !variables._dataStreamAssured ) {
 			this.onRegistration();
 			// skip out if there was a communication failure
-			if( !variables._dataStreamAssured ){
+			if ( !variables._dataStreamAssured ) {
 				return;
 			}
 		}
@@ -151,8 +150,11 @@ component
 
 		try {
 			var document = newDocument().new( index = getProperty( "dataStream" ), properties = logObj );
-			if( getProperty( "async" ) ){
-				variables.asyncManager.newFuture().withTimeout( getProperty( "asyncTimeout" ) ).run( () => document.create() );
+			if ( getProperty( "async" ) ) {
+				variables.asyncManager
+					.newFuture()
+					.withTimeout( getProperty( "asyncTimeout" ) )
+					.run( () => document.create() );
 			} else {
 				document.create();
 			}
@@ -166,12 +168,12 @@ component
 					extraInfo = { "logData" : logObj, "exception" : e },
 					category  = e.type
 				);
-				var appendersMap  = application.wirebox.getLogbox().getAppenderRegistry();
+				var appendersMap = application.wirebox.getLogbox().getAppenderRegistry();
 				// Log errors out to other appenders besides this one
 				appendersMap
 					.keyArray()
 					.filter( function( key ){
-						return lcase( key ) != lcase( getName() );
+						return lCase( key ) != lCase( getName() );
 					} )
 					.each( function( appenderName ){
 						appendersMap[ appenderName ].logMessage( eLogEvent );
@@ -366,7 +368,9 @@ component
 		if ( propertyExists( "lifecyclePolicy" ) ) {
 			policyBuilder.setPhases( getProperty( "lifecyclePolicy" ) );
 		} else {
-			policyBuilder.hotPhase( rollover=getProperty( "rolloverSize" ) ).withDeletion( age = getProperty( "retentionDays" ) );
+			policyBuilder
+				.hotPhase( rollover = getProperty( "rolloverSize" ) )
+				.withDeletion( age = getProperty( "retentionDays" ) );
 		}
 
 		policyBuilder.save();
@@ -407,7 +411,9 @@ component
 				],
 				"data_stream" : {},
 				"priority"    : getProperty( "indexTemplatePriority" ),
-				"_meta"       : { "description" : "Index Template for cbElasticsearch Logs ( DataStream: #dataStreamName# )" }
+				"_meta"       : {
+					"description" : "Index Template for cbElasticsearch Logs ( DataStream: #dataStreamName# )"
+				}
 			}
 		);
 
@@ -645,7 +651,7 @@ component
 				"dynamic_templates" : [
 					{
 						"user_info_fields" : {
-							"path_match"              : "user.info.*",
+							"path_match"         : "user.info.*",
 							"match_mapping_type" : "string",
 							"mapping"            : {
 								"type"   : "text",
@@ -682,17 +688,11 @@ component
 					},
 					"error" : {
 						"type"       : "object",
-						"properties" : {
-							"extrainfo" : { "type" : "text" }
-						}
+						"properties" : { "extrainfo" : { "type" : "text" } }
 					},
 					"message" : {
 						"type"   : "text",
-						"fields" : {
-							"keyword" : {
-								"type" : "keyword", "ignore_above" : 512
-							}
-						}
+						"fields" : { "keyword" : { "type" : "keyword", "ignore_above" : 512 } }
 					},
 					"event" : {
 						"type"       : "object",
@@ -709,7 +709,7 @@ component
 						"properties" : {
 							"signature"    : { "type" : "keyword" },
 							"isSuppressed" : { "type" : "boolean" },
-							"assignment" : { "type" : "keyword" }
+							"assignment"   : { "type" : "keyword" }
 						}
 					}
 				}

--- a/models/util/Util.cfc
+++ b/models/util/Util.cfc
@@ -95,13 +95,13 @@ component accessors="true" singleton {
 				&& !isSimpleValue( errorPayload.error )
 				&& errorPayload.error.keyExists( "root_cause" )
 			)
-			 ? " Reason: #isArray( errorPayload.error.root_cause ) ? errorPayload.error.root_cause[ 1 ].reason : errorPayload.error.root_cause.reason#"
+			 ? " Reason: #isArray( errorPayload.error.root_cause ) ? ( errorPayload.error.root_cause[ 1 ].reason ?: 'None' ) : ( errorPayload.error.root_cause.reason ?: 'None' )#"
 			 : (
 				structKeyExists( errorPayload, "error" )
 				 ? (
 					isSimpleValue( errorPayload.error )
 					 ? " Reason: #errorPayload.error# "
-					 : " Reason: #errorPayload.error.reason#"
+					 : " Reason: #errorPayload.error.reason ?: 'None'#"
 				)
 				 : ""
 			);

--- a/models/util/Util.cfc
+++ b/models/util/Util.cfc
@@ -95,13 +95,15 @@ component accessors="true" singleton {
 				&& !isSimpleValue( errorPayload.error )
 				&& errorPayload.error.keyExists( "root_cause" )
 			)
-			 ? " Reason: #isArray( errorPayload.error.root_cause ) ? ( errorPayload.error.root_cause[ 1 ].reason ?: 'None' ) : ( errorPayload.error.root_cause.reason ?: 'None' )#"
+			 ? " Reason: #isArray( errorPayload.error.root_cause ) ? ( errorPayload.error.root_cause[ 1 ].reason ?: "None" ) : (
+				errorPayload.error.root_cause.reason ?: "None"
+			)#"
 			 : (
 				structKeyExists( errorPayload, "error" )
 				 ? (
 					isSimpleValue( errorPayload.error )
 					 ? " Reason: #errorPayload.error# "
-					 : " Reason: #errorPayload.error.reason ?: 'None'#"
+					 : " Reason: #errorPayload.error.reason ?: "None"#"
 				)
 				 : ""
 			);


### PR DESCRIPTION
Adds defensive coding for explained cases where a `reason` is missing from an error response:

```js
Error calling CruiseSearchAPIv1:Search.index: the value from key [REASON]  is NULL, which is the same as not existing in CFML Query: {"query":{"bool":{"filter":{"bool":{"must":[{"term":{"isCruiseTour":false}},{"term":{"region.kw":"Caribbean"}}]}},...
```

Due to the error in the error handler, I can't even tell where/when this error occurs.