### PR TITLE
Add runtime mappings support via addRuntimeMapping()

### DIFF
--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -162,7 +162,7 @@ var interest = searchBuilder.execute().getHits().map( (document) => document.get
 
 ### Runtime Fields
 
-Elasticsearch also allows the creation of runtime fields, which are fields defined in the index mapping but populated at search time via a script.
+Elasticsearch also supports defining runtime fields, which are fields defined in the index mapping but populated at search time via a script. You can [define these in the index mapping](../Indices/Managing-Indices.md#creating-runtime-fields), or [define them at search time](#define-runtime-fields-at-search-time).
 
 {% hint style="info" %}
 See [Managing-Indices](../Indices/Managing-Indices.md#creating-runtime-fields) for more information on creating runtime fields.
@@ -204,9 +204,9 @@ for( hit in result.getHits() ){
 ```
 
 
-### Runtime Mappings
+### Define Runtime Fields At Search Time
 
-SearchBuilder also supports [Elasticsearch runtime mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html), which allow you to define a field in the index mapping which is generated or computed at runtime, but unlike [script fields](#script-fields) are available to use in aggregations, search queries, and so forth.
+Elasticsearch also allows you to [define runtime fields at search time](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-search-request.html), and unlike [script fields](#script-fields) these runtime fields are available to use in aggregations, search queries, and so forth.
 
 ```js
 searchBuilder.addRuntimeMapping( "hasPricing", {

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -203,6 +203,28 @@ for( hit in result.getHits() ){
 }
 ```
 
+
+### Runtime Mappings
+
+SearchBuilder also supports [Elasticsearch runtime mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html), which allow you to define a field in the index mapping which is generated or computed at runtime, but unlike [script fields](#script-fields) are available to use in aggregations, search queries, and so forth.
+
+```js
+searchBuilder.addRuntimeMapping( "hasPricing", {
+	"type" : "boolean",
+	"script": {
+		"source": "doc.containsKey( 'price' )"
+	}
+} );
+```
+
+This will result in an `"hasPricing"` field in the `fields` property on the `Document` object:
+
+```js
+var documentsWithPricing = searchBuilder.execute()
+	.getHits()
+	.filter( (document) => document.getFields()["hasPricing"] );
+```
+
 ### Advanced Query DSL
 
 The SearchBuilder also allows full use of the [Elasticsearch query language](https://www.elastic.co/guide/en/elasticsearch/reference/current/_introducing_the_query_language.html), allowing full configuration of your search queries. There are several methods to provide the raw query language to the Search Builder. One is during instantiation.

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -217,13 +217,21 @@ searchBuilder.addRuntimeMapping( "hasPricing", {
 } );
 ```
 
-This will result in an `"hasPricing"` field in the `fields` property on the `Document` object:
+Using `.addField()` ensures the field is returned with the document upon query completion:
+
+```js
+searchBuilder.addRuntimeMapping( "hasPricing", ... ).addField( "hasPricing" );
+```
+
+We can then retrieve the result field via the `getFields()` method:
 
 ```js
 var documentsWithPricing = searchBuilder.execute()
 	.getHits()
 	.filter( (document) => document.getFields()["hasPricing"] );
 ```
+
+or inlined with the document mento using `hit.getDocument( includeFields = true )`.
 
 ### Advanced Query DSL
 

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -58,6 +58,13 @@ component accessors="true" {
 	property name="scriptFields" type="struct";
 
 	/**
+	 * Property containing elasticsearch "runtime_mappings" definition for runtime scripted fields
+	 *
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html
+	 */
+	property name="runtimeMappings" type="struct";
+
+	/**
 	 * Property containing "fields" array of fields to return for each hit
 	 *
 	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html
@@ -1247,6 +1254,10 @@ component accessors="true" {
 			dsl[ "script_fields" ] = variables.scriptFields;
 		}
 
+		if ( !isNull( variables.runtimeMappings ) ) {
+			dsl[ "runtime_mappings" ] = variables.runtimeMappings;
+		}
+
 		if ( !isNull( variables.fields ) ) {
 			dsl[ "fields" ] = variables.fields;
 		}
@@ -1359,6 +1370,25 @@ component accessors="true" {
 			variables.fields = [];
 		}
 		variables.fields.append( arguments.value );
+		return this;
+	}
+
+	/**
+	 * Append a search-time (runtime) mapping to the search.
+	 *
+	 * @name Name of the runtime mapping field
+	 * 
+	 * @script Script to use. `{ "script" : { "lang": "painless", "source" : } }`
+	 */
+	public SearchBuilder function addRuntimeMapping(
+		required string name,
+		struct script,
+		any source = true
+	){
+		if ( isNull( variables.runtimeMappings ) ) {
+			variables.runtimeMappings = {};
+		}
+		variables.runtimeMappings[ arguments.name ] = arguments.script;
 		return this;
 	}
 

--- a/models/SearchBuilder.cfc
+++ b/models/SearchBuilder.cfc
@@ -1373,6 +1373,7 @@ component accessors="true" {
 		return this;
 	}
 
+
 	/**
 	 * Append a search-time (runtime) mapping to the search.
 	 *
@@ -1382,8 +1383,7 @@ component accessors="true" {
 	 */
 	public SearchBuilder function addRuntimeMapping(
 		required string name,
-		struct script,
-		any source = true
+		struct script
 	){
 		if ( isNull( variables.runtimeMappings ) ) {
 			variables.runtimeMappings = {};

--- a/test-harness/tests/specs/unit/SearchBuilderTest.cfc
+++ b/test-harness/tests/specs/unit/SearchBuilderTest.cfc
@@ -830,6 +830,20 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				expect( searchBuilder.getDSL()[ "script_fields" ] ).toHaveKey( "with5PercentDiscount" );
 			} );
 
+			it( "Tests the addRuntimeMapping() method", function(){
+				var searchBuilder = variables.model.new( variables.testIndexName, "testdocs" );
+
+				searchBuilder.addRuntimeMapping( "hasPricing", {
+					"type" : "boolean",
+					"script": {
+						"source": "doc.containsKey( 'price' )"
+					}
+				} );
+	
+				expect( searchBuilder.getDSL() ).toBeStruct().toHaveKey( "runtime_mappings" );
+				expect( searchBuilder.getDSL()[ "runtime_mappings" ] ).toHaveKey( "hasPricing" );
+			} );
+
 			it( "Tests the addField() method for retrieving runtime or other fields", function(){
 				var search = variables.model.new( variables.testIndexName, "testdocs" );
 


### PR DESCRIPTION
Implement [Elasticsearch runtime mappings](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-search-request.html) via a new `addRuntimeMapping()` method in the search builder:

```js
searchBuilder.addRuntimeMapping( "hasPricing", {
	"type" : "boolean",
	"script": {
		"source": "doc.containsKey( 'price' )"
	}
} );
```

Using `.addField()` ensures the field is returned with the document upon query completion:
```js
searchBuilder.addRuntimeMapping( "hasPricing", ... )
.addField( "hasPricing" );
```

We can retrieve the result field via the `getFields()` method:

```js
var documentsWithPricing = searchBuilder.execute()
	.getHits()
	.filter( (document) => document.getFields()["hasPricing"] );
```

or inlined with the document mento using `hit.getDocument( includeFields = true )`.