### PR TITLE
Ensure we use lowercase @cbelasticsearch in docs getInstance() calls

### DIFF
--- a/docs/Documents.md
+++ b/docs/Documents.md
@@ -11,7 +11,7 @@ Documents are the searchable, serialized objects within your indexes.  As noted 
 The `Document` model is the primary object for creating and working with Documents.  Let's say, again, we were going to create a new document in our index.  We would do so, by first creating a `Document` object.
 
 ```js
-var book = getInstance( "Document@cbElasticsearch" ).new(
+var book = getInstance( "Document@cbelasticsearch" ).new(
     index = "bookshop",
     type = "_doc",
     properties = {
@@ -60,7 +60,7 @@ To retrieve an existing document, we must first know the `_id` value.  We can ei
 Using the `Document` object's accessors:
 
 ```js
-var existingDocument = getInstance( "Document@cbElasticsearch" )
+var existingDocument = getInstance( "Document@cbelasticsearch" )
     .setIndex( "bookshop" )
     .setType( "_doc" )
     .setId( bookId )
@@ -70,7 +70,7 @@ var existingDocument = getInstance( "Document@cbElasticsearch" )
 Calling the `get()` method with explicit arguments:
 
 ```js
-var existingDocument = getInstance( "Document@cbElasticsearch" )
+var existingDocument = getInstance( "Document@cbelasticsearch" )
     .get(
         id = bookId,
         index = "bookshop",
@@ -81,7 +81,7 @@ var existingDocument = getInstance( "Document@cbElasticsearch" )
 Calling directly, using the same arguments, from the client:
 
 ```js
-var existingDocument = getInstance( "Client@cbElasticsearch" )
+var existingDocument = getInstance( "Client@cbelasticsearch" )
     .get(
         id = bookId,
         index = "bookshop",
@@ -92,7 +92,7 @@ var existingDocument = getInstance( "Client@cbElasticsearch" )
 The `get` method also accepts a struct of [query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html#docs-get-api-query-params) to pass to the document retrieval request.  For example, we only want certain items returned in the document JSON, we can pass a `_source_includes` query parameter:
 
 ```js
-var minimal = getInstance( "Client@cbElasticsearch" )
+var minimal = getInstance( "Client@cbelasticsearch" )
     .get(
         id = bookId,
         index = "bookshop",
@@ -116,7 +116,7 @@ existingDocument.populate( properties = myUpdatedBookStruct ).save()
 You can also pass Document objects to the `Client`'s `save()` method:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).save( existingDocument );
+getInstance( "Client@cbelasticsearch" ).save( existingDocument );
 ```
 
 #### Save Documents with an Index Refresh
@@ -124,7 +124,7 @@ getInstance( "Client@cbElasticsearch" ).save( existingDocument );
 If you need your document available immediately (such as during a test or pipeline), you can pass `refresh = true` to [instruct Elasticsearch to refresh the relevant index shard immediately and synchronously](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html):
 
 ```js
-getInstance( "Client@cbElasticsearch" ).save(
+getInstance( "Client@cbelasticsearch" ).save(
     document = existingDocument,
     refresh = true
 );
@@ -133,7 +133,7 @@ getInstance( "Client@cbElasticsearch" ).save(
 The refresh parameter also accepts a `wait_for` option, which tells Elasticsearch to wait until the next index refresh:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).save(
+getInstance( "Client@cbelasticsearch" ).save(
     document = existingDocument,
     refresh = "wait_for"
 );
@@ -144,7 +144,7 @@ getInstance( "Client@cbElasticsearch" ).save(
 The `patch` method of the Client allows a user to update select fields, bypassing the need for a fully retrieved document.  This is similar to an `UPDATE foo SET bar = 'xyz' WHERE id = :id` query on a relational database.  The method requires an index name, identifier and a struct containing the keys to be updated:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).patch( 
+getInstance( "Client@cbelasticsearch" ).patch( 
     "bookshop",
     bookId,
     {
@@ -156,7 +156,7 @@ getInstance( "Client@cbElasticsearch" ).patch(
 Nested keys can also be updated using dot-notation:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).patch(
+getInstance( "Client@cbelasticsearch" ).patch(
     "bookshop",
     bookId,
     {
@@ -202,7 +202,7 @@ var ops = [
     }
 ];
 
-getInstance( "Client@cbElasticsearch" ).processBulkOperation( ops, { "refresh" : true } );
+getInstance( "Client@cbelasticsearch" ).processBulkOperation( ops, { "refresh" : true } );
 ```
 
 #### Bulk Saving of Documents
@@ -213,7 +213,7 @@ Builk inserts and updates can be peformed by passing an array of `Document` obje
 var documents = [];
 
 for( var myStruct in myArray ){
-    var document = getInstance( "Document@cbElasticsearch" ).new(
+    var document = getInstance( "Document@cbelasticsearch" ).new(
         index = myIndex,
         type = myType,
         properties = myStruct
@@ -222,7 +222,7 @@ for( var myStruct in myArray ){
     arrayAppend( documents, document );
 }
 
-getInstance( "Client@cbElasticsearch" ).saveAll( documents );
+getInstance( "Client@cbelasticsearch" ).saveAll( documents );
 ```
 
 
@@ -233,9 +233,9 @@ For advanced updates to documents in the index, the `updateByQuery` method can p
 Let's say, for example, that you need to add a new key, with a default value, to every document in your index where the key does not already exist:
 
 ```js
-var searchBuilder = getInstance( "SearchBuilder@cbElasticsearch" )
+var searchBuilder = getInstance( "SearchBuilder@cbelasticsearch" )
                         .mustNotExist( "isInPrint" );
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
             .updateByQuery(
                 searchBuilder,
                 {
@@ -252,12 +252,12 @@ Note the variable `ctx._source` used in the script, which is a reference to the 
 Note that a Painless script containing newlines, tabs, or space indentation will throw a parsing error. To work around this limitation, use CBElasticsearch's `Util.formatToPainless( string script )` method to remove newlines and indentation:
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
             .updateByQuery(
                 searchBuilder,
                 {
                     "lang" : "painless",
-                    "script" : getInstance( "Util@cbElasticsearch" )
+                    "script" : getInstance( "Util@cbelasticsearch" )
                                 .formatToPainless( getReindexScript() )
                 }
             );
@@ -269,7 +269,7 @@ getInstance( "Client@cbElasticsearch" )
 Deleting documents is similar to the process of saving.  The `Document` object may be used to delete a single item.
 
 ```js
-var document = getInstance( "Document@cbElasticsearch" )
+var document = getInstance( "Document@cbelasticsearch" )
     .get(
         id = documentId,
         index = "bookshop",
@@ -283,13 +283,13 @@ if( !isNull( document ) ){
 Documents may also be deleted by passing a `Document` instance to the client:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).delete( myDocument );
+getInstance( "Client@cbelasticsearch" ).delete( myDocument );
 ```
 
 Finally, documents may also be deleted by query, using the `SearchBuilder` ( more below ):
 
 ```js
-getInstance( "SearchBuilder@cbElasticsearch" )
+getInstance( "SearchBuilder@cbelasticsearch" )
     .new( index="bookshop", type="books" )
     .match( "name", "Elasticsearch for Coldbox" )
     .deleteAll();
@@ -305,7 +305,7 @@ The search builder also supports the addition of URL parameters, which may be us
 Of note are the throttling parameters, which are useful in dealing with large documents and/or indices.  By default elasticsearch processes batch operations in groups of 1000 documents.  Depending on the size of your documents and the collection, it may be preferable to throttle the batch to a smaller number of documents per batch:
 
 ```js
-getInstance( "SearchBuilder@cbElasticsearch" )
+getInstance( "SearchBuilder@cbelasticsearch" )
     .new( index="bookshop", type="books" )
     .match( "name", "Elasticsearch for Coldbox" )
     .param( "scroll_size", 100 )

--- a/docs/Getting-Started/Configuration.md
+++ b/docs/Getting-Started/Configuration.md
@@ -12,7 +12,7 @@ By default the following are in place, without additional configuration:
 moduleSettings = {
     "cbElasticsearch" = {
         //The native client Wirebox DSL for the transport client
-        client="HyperClient@cbElasticsearch",
+        client="HyperClient@cbelasticsearch",
         // The default hosts - an array of host connections
         //  - REST-based clients (e.g. JEST):  round robin connections will be used
         //  - Socket-based clients (e.g. Transport):  cluster-aware routing used

--- a/docs/Getting-Started/Secondary-Cluster.md
+++ b/docs/Getting-Started/Secondary-Cluster.md
@@ -70,7 +70,7 @@ var secondaryConfig = wirebox.getInstance( "Config@SecondaryCluster" );
 // note that we need a full config structure passed in as an override to the coldbox settings
 secondaryConfig.setConfigStruct( settings );
 
-// note that we are using the native JEST client rather than Client@cbElasticsearch
+// note that we are using the native JEST client rather than Client@cbelasticsearch
 binder.map( "Client@SecondaryCluster" )
                         .to( "cbElasticsearch.models.JestClient" )
                         .initWith( configuration=secondaryConfig )
@@ -91,7 +91,7 @@ if( wirebox.containsInstance( "Client@SecondaryCluster" ) ){
 Now you may perform a search, considering the caveat that the search must now be executed through the client:
 
 ```js
-var searchBuilder = getInstance( "SearchBuilder@cbElasticsearch" ).new( "myOtherIndex" );
+var searchBuilder = getInstance( "SearchBuilder@cbelasticsearch" ).new( "myOtherIndex" );
 searchBuilder.term( "foo", "bar" );
 
 var searchResult = getInstance( "Client@SecondaryCluster" ).executeSearch( searchBuilder );
@@ -100,7 +100,7 @@ var searchResult = getInstance( "Client@SecondaryCluster" ).executeSearch( searc
 Document saves, retrievals, and deletions would need to be routed through the client, as well, rather than using the `save()` function:
 
 ```js
-var newDocument = getInstance( "Document@cbElasticsearch" ).new( { "id" : createUUID(), "foo" : "bar" } );
+var newDocument = getInstance( "Document@cbelasticsearch" ).new( { "id" : createUUID(), "foo" : "bar" } );
 getInstance( "Client@SecondaryCluster" ).save( newDocument );
 
 

--- a/docs/Indices/Aliases.md
+++ b/docs/Indices/Aliases.md
@@ -41,7 +41,7 @@ variables.client.applyAliases(
 The client's `getAliases` method allows you to retrieve a map containing information on aliases in use in the connected cluster.
 
 ```js
-var aliasMap = getInstance( "Client@cbElasticsearch" ).getAliases();
+var aliasMap = getInstance( "Client@cbelasticsearch" ).getAliases();
 ```
 
 The corresponding object will have two keys: `aliases` and `unassigned`. The former is a map of aliases with their corresponding index, the latter is an array of indexes which are unassigned to any alias.

--- a/docs/Indices/Data-Streams.md
+++ b/docs/Indices/Data-Streams.md
@@ -100,7 +100,7 @@ Now we can create our data stream in one of two ways. We can either send data to
 Create a data stream manually without data:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).ensureDataStream( "my-index-foo" );
+getInstance( "Client@cbelasticsearch" ).ensureDataStream( "my-index-foo" );
 ```
 
 This will create the data stream and backing indices for the data stream named `my-index-foo`.  

--- a/docs/Indices/Managing-Indices.md
+++ b/docs/Indices/Managing-Indices.md
@@ -13,7 +13,7 @@ By default, Elasticsearch will dynamically generate these index mapping when a d
 To retrieve a list of all indices on the connected cluster, use the client `getIndices` method:
 
 ```js
-var indexMap = getInstance( "Client@cbElasticsearch" ).getIndices();
+var indexMap = getInstance( "Client@cbelasticsearch" ).getIndices();
 ```
 
 This will return a struct of all indices ( with the names as keys ), which will provide additional information on each index, such as:
@@ -27,7 +27,7 @@ This will return a struct of all indices ( with the names as keys ), which will 
 The `IndexBuilder` model assists with the creation and mapping of indices. Mappings define the allowable data types within your documents and allow for better and more accurate search aggregations. Let's say we have a book model that we intend to make searchable via a `bookshop` index. Let's go ahead and create the index using the IndexBuilder:
 
 ```js
-var indexBuilder = getInstance( "IndexBuilder@cbElasticsearch" ).new( "bookshop" ).save();
+var indexBuilder = getInstance( "IndexBuilder@cbelasticsearch" ).new( "bookshop" ).save();
 ```
 
 This will create an empty index which we can begin populating with documents.
@@ -37,7 +37,7 @@ This will create an empty index which we can begin populating with documents.
 To avoid the inherent troubles with dynamic mappings, you can define an explicit mapping using the `properties` argument:
 
 ```js
-getInstance( "IndexBuilder@cbElasticsearch" )
+getInstance( "IndexBuilder@cbelasticsearch" )
     .new(
         name = "bookshop",
         properties = {
@@ -64,12 +64,12 @@ While it is not *required* that you explicitly define an index mapping, it is **
 
 ## Using Client.ApplyIndex
 
-In the previous examples, we've created the index and mapping from the IndexBuilder itself. If we wish, we could instead pass the `IndexBuilder` object to the `Client@cbElasticsearch` instance's `applyIndex( required IndexBuilder indexBuilder )` method:
+In the previous examples, we've created the index and mapping from the IndexBuilder itself. If we wish, we could instead pass the `IndexBuilder` object to the `Client@cbelasticsearch` instance's `applyIndex( required IndexBuilder indexBuilder )` method:
 
 ```js
 var myNewIndex = indexBuilder.new( "bookshop" )
                     .populate( getInstance( "BookshopIndexConfig@myApp" ).getConfig() );
-getInstance( "Client@cbElasticsearch" ).applyIndex( myNewIndex );
+getInstance( "Client@cbelasticsearch" ).applyIndex( myNewIndex );
 ```
 
 ## Configuring Index Settings
@@ -140,13 +140,13 @@ indexBuilder.patch(
 To retreive a list of all settings for an index you may use the `getSettings` method on the client. 
 
 ```js
-var indexSettings = getInstance( "Client@CBElasticsearch" ).getSettings( "bookshop" )
+var indexSettings = getInstance( "Client@cbelasticsearch" ).getSettings( "bookshop" )
 ```
 ## Retrieving Mappings for an Index
 To retreive a list of the configured mappings for an index you may use the `getMappings` method on the client. 
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" ).getMappings( "reviews" );
+var mappings = getInstance( "Client@cbelasticsearch" ).getMappings( "reviews" );
 ```
 
 ## Triggering an index refresh
@@ -154,21 +154,21 @@ var mappings = getInstance( "Client@CBElasticsearch" ).getMappings( "reviews" );
 On occasion, you may need to ensure the index is updated in real time (immediately and synchronously). This can be done via the `refreshIndex()` client method:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex( "reviews" );
+var mappings = getInstance( "Client@cbelasticsearch" ).refreshIndex( "reviews" );
 ```
 
 You can refresh multiple indices at once:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex( [ "reviews", "books" ] );
+var mappings = getInstance( "Client@cbelasticsearch" ).refreshIndex( [ "reviews", "books" ] );
 // OR
-var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex( "reviews,books" );
+var mappings = getInstance( "Client@cbelasticsearch" ).refreshIndex( "reviews,books" );
 ```
 
 as well as pass [supported query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html#refresh-api-query-params) to the refresh endpoint. This can be useful when using wildcards in the index/alias names:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex(
+var mappings = getInstance( "Client@cbelasticsearch" ).refreshIndex(
     [ "reviews", "book*" ],
     { "ignore_unavailable" : true }
 );
@@ -179,33 +179,33 @@ var mappings = getInstance( "Client@CBElasticsearch" ).refreshIndex(
 To retrieve statistics on an index, use the `getIndexStats()` method:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" ).getIndexStats( "reviews" );
+var mappings = getInstance( "Client@cbelasticsearch" ).getIndexStats( "reviews" );
 ```
 
 You can retrieve particular statistics metrics:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" )
+var mappings = getInstance( "Client@cbelasticsearch" )
                     .getIndexStats( "reviews", [ "indexing", "search" ] );
 ```
 
 Or all metrics:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" )
+var mappings = getInstance( "Client@cbelasticsearch" )
                     .getIndexStats( "reviews", [ "_all" ] );
 ```
 
 You can even retrieve all metrics on all indices by skipping the `indexName` parameter entirely:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" ).getIndexStats();
+var mappings = getInstance( "Client@cbelasticsearch" ).getIndexStats();
 ```
 
 Finally, you can pass a struct of parameters to fine-tune the statistics result:
 
 ```js
-var mappings = getInstance( "Client@CBElasticsearch" )
+var mappings = getInstance( "Client@cbelasticsearch" )
                     .getIndexStats(
                         "reviews",
                         [ "_all" ],
@@ -218,14 +218,14 @@ var mappings = getInstance( "Client@CBElasticsearch" )
 Elasticsearch allows [mapping runtime fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-mapping-fields.html), which are fields calculated at search time and returned in the `"fields"` array.
 
 ```js
-var script = getInstance( "Util@CBElasticsearch" )
+var script = getInstance( "Util@cbelasticsearch" )
 .formatToPainless("
   if( doc['summary'].value.contains('love') ){ emit('😍');}
   if( doc['summary'].value.contains('great') ){ emit('🚀');}
   if( doc['summary'].value.contains('hate') ){ emit('😡');}
   if( doc['summary'].value.contains('broke') ){ emit('💔');}
 ");
-getInstance( "Client@CBElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
         .patch( "reviews", {
             "mappings" : {
                 "runtime" : {
@@ -247,7 +247,7 @@ This `summarized_emotions` field [can then be retrieved during a search](https:/
 All good things must come to an end, eh? You can use `Client.deleteIndex()` to delete an existing index:
 
 ```js
-getInstance( "Client@CBElasticsearch" ).deleteIndex( "reviews" )
+getInstance( "Client@cbelasticsearch" ).deleteIndex( "reviews" )
 ```
 
 Or you can use `IndexBuilder.delete()`:

--- a/docs/Indices/Reindexing.md
+++ b/docs/Indices/Reindexing.md
@@ -8,7 +8,7 @@ On occasion, due to a mapping or settings change, you will need to reindex data
 from one index (the "source") to another (the "destination"). You can do this by calling the `reindex` method on CBElasticsearch's `Client` component.
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
     .reindex( "oldIndex", "newIndex" );
 ```
 
@@ -17,7 +17,7 @@ getInstance( "Client@cbElasticsearch" )
 If you want the work to be done asynchronusly, you can pass `false` to the `waitForCompletion` flag. When this flag is set to false the method will return a [`Task` instance](../Tasks.md), which can be used to follow up on the completion status of the reindex process.
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
     .reindex(
         source = "oldIndex",
         destination = "newIndex",
@@ -30,7 +30,7 @@ getInstance( "Client@cbElasticsearch" )
 If you have more settings or constraints for the reindex action, you can pass a struct containing valid options to `source` and `destination`.
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
     .reindex(
         source = {
             "index": "oldIndex",
@@ -50,7 +50,7 @@ getInstance( "Client@cbElasticsearch" )
 You may also pass a script in to the `reindex` method to transform objects as they are being transferred from one index to another:
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
     .reindex(
         source = {
             "index": "oldIndex",
@@ -72,12 +72,12 @@ getInstance( "Client@cbElasticsearch" )
 Note that a Painless script containing newlines, tabs, or space indentation will throw a parsing error. To work around this limitation, use CBElasticsearch's `Util.formatToPainless( string script )` method to remove newlines and indentation:
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
     .reindex(
         // ...
         script = {
             "lang" : "painless",
-            "source" : getInstance( "Util@cbElasticsearch" )
+            "source" : getInstance( "Util@cbelasticsearch" )
                         .formatToPainless( getReindexScript() )
         }
     );
@@ -88,7 +88,7 @@ getInstance( "Client@cbElasticsearch" )
 If you `waitForCompletion` and the reindex action fails, a `cbElasticsearch.HyperClient.ReindexFailedException` will be thrown. You can disable the exception by passing `false` to the `throwOnError` parameter:
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
     .reindex(
         source = "oldIndex",
         destination = "newIndex",

--- a/docs/Pipelines.md
+++ b/docs/Pipelines.md
@@ -41,7 +41,7 @@ myPipeline.save();
 Or through the client:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).applyPipeline( myPipeline );
+getInstance( "Client@cbelasticsearch" ).applyPipeline( myPipeline );
 ```
 
 Note that if you are using a [secondary cluster](Configuration.md), you will need to perform your CRUD operations through the client, as the `save` method in the pipeline object will route through the top level client. 
@@ -51,13 +51,13 @@ Note that if you are using a [secondary cluster](Configuration.md), you will nee
 If we know the name of our pipeline, we can retreive the definition from Elasticsearch by using the `getPipeline` method of the client: 
 
 ```js
-getInstance( "Client@cbElasticsearch" ).getPipeline( "foo-pipeline" );
+getInstance( "Client@cbelasticsearch" ).getPipeline( "foo-pipeline" );
 ```
 
 If we need to retreive the definitions of all configured pipelines we can call the `getPipelines` method:
 
 ```js
-getInstance( "Client@cbElasticsearch" ).getPipelines();
+getInstance( "Client@cbelasticsearch" ).getPipelines();
 ```
 
 
@@ -66,8 +66,8 @@ getInstance( "Client@cbElasticsearch" ).getPipelines();
 We can modify pipelines using the pipeline object, as well. Let's do this by retrieving the existing pipeline, updating and then saving it:
 
 ```js
-var pipeline = getInstance( "Pipeline@cbElasticsearch" )
-                .new( getInstance( "Client@cbElasticsearch" )
+var pipeline = getInstance( "Pipeline@cbelasticsearch" )
+                .new( getInstance( "Client@cbelasticsearch" )
                 .getPipeline( "foo-pipeline" ) );
 
 pipeline.addProcessor(
@@ -105,6 +105,6 @@ myDocument.setPipeline( 'foo-pipeline' ).save();
 For multiple documents, the pipeline may be set in the document, prior to the `saveAll` call.  Note, however, that all documents provided in the bulk save must share the same pipeline, as elasticsearch does not support multiple pipelines in bulk saves.  Attempting to save multiple documents with different pipelines will throw an error. Alternately, you may pass the pipeline in as a param to the `saveAll` call:
 
 ```js
-getInstance( "Client@cbElasticsearch" )
+getInstance( "Client@cbelasticsearch" )
 	.saveAll( documents=myDocuments, params={ "pipeline" : "foo-pipeline" } );
 ```

--- a/docs/Searching/Search.md
+++ b/docs/Searching/Search.md
@@ -7,7 +7,7 @@ description: Learn how to search documents with CBElasticsearch
 The `SearchBuilder` object offers an expressive syntax for crafting detailed searches with ranked results. To perform a simple search for matching documents documents, using Elasticsearch's automatic scoring, we would use the `SearchBuilder` like so:
 
 ```js
-var searchResults = getInstance( "SearchBuilder@cbElasticsearch" )
+var searchResults = getInstance( "SearchBuilder@cbelasticsearch" )
     .new( index="bookshop", type="books" )
     .match( "name", "Elasticsearch" )
     .execute();
@@ -240,7 +240,7 @@ The SearchBuilder also allows full use of the [Elasticsearch query language](htt
 In the following we are looking for matches of active records with "Elasticsearch" in the `name`, `description`, or `shortDescription` fields. We are also looking for a phrase match of "is awesome" and are boosting the score of the applicable document, if found.
 
 ```js
-var search = getInstance( "SearchBuilder@cbElasticsearch" )
+var search = getInstance( "SearchBuilder@cbelasticsearch" )
     .new(
         index = "bookshop",
         type = "books",
@@ -269,7 +269,7 @@ var search = getInstance( "SearchBuilder@cbElasticsearch" )
 After instantion, you can use the `.param()` and `.bodyParam()` methods to set [query parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-query-params) and [body parameters](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/search-search.html#search-search-api-request-body), respectively.
 
 ```js
-var response = getInstance( "SearchBuilder@cbElasticsearch" )
+var response = getInstance( "SearchBuilder@cbelasticsearch" )
     .new( "bookshop" )
     .sort( "publishDate DESC" )
     // match everything
@@ -295,7 +295,7 @@ The `collapseToField` allows you to collapse the results of the search to a spec
 Let's say, for example, we want to find the most recent version of a book in our index, for all books matching the phrase "Elasticsearch". In this case, we can group on the `title` field ( or, in this case `title.keyword`, which is a dynamic keyword-typed field in our index ) to retrieve the most recent version of the book.
 
 ```js
-var searchResults = getInstance( "SearchBuilder@cbElasticsearch" )
+var searchResults = getInstance( "SearchBuilder@cbelasticsearch" )
                                 .new( index="bookshop" )
                                 .mustMatch( "description", "Elasticsearch" )
                                 .collapseToField( "title.keyword" )
@@ -313,7 +313,7 @@ For more information on field collapsing, see the [Collapse Search Results Docum
 `collapseToField()` also supports an `includeOccurrences` option. By passing `includeOccurrences=true` to `collapseToField`, you can retrieve a map of all collapsed key values and their corresponding document count by calling `searchResult.getCollapsedOccurrences()`:
 
 ```js
-var elasticsearchBookTitles = getInstance( "SearchBuilder@cbElasticsearch" )
+var elasticsearchBookTitles = getInstance( "SearchBuilder@cbelasticsearch" )
                                 .new( index="bookshop" )
                                 .mustMatch( "description", "Elasticsearch" )
                                 .collapseToField( field = "title.keyword", includeOccurrences = {} )
@@ -330,7 +330,7 @@ For more information on field collapsing, see the [Collapse Search Results Docum
 Sometimes you only need a count of matching documents, rather than the results of the query. When this is the case, you can call the `count()` method from the search builder ( or using the client ) to only return the number of matched documents and omit the result set and metadata:
 
 ```js
-var docCount = getInstance( "SearchBuilder@cbElasticsearch" )
+var docCount = getInstance( "SearchBuilder@cbelasticsearch" )
     .new(
         index = "bookshop",
         type = "books",
@@ -375,7 +375,7 @@ On occasion, you may wish to show a set of terms matching a partial string. This
 To retrieve this data, you can use the client's `getTermsEnum()` method:
 
 ```js
-var terms = getInstance( "HyperClient@cbElasticsearch" )
+var terms = getInstance( "HyperClient@cbelasticsearch" )
             .getTermsEnum(
                 indexName  = "hotels",
                 field = "city",
@@ -388,7 +388,7 @@ var terms = getInstance( "HyperClient@cbElasticsearch" )
 For advanced lookups, you can use the second argument to pass a struct of custom options:
 
 ```js
-var terms = getInstance( "HyperClient@cbElasticsearch" )
+var terms = getInstance( "HyperClient@cbelasticsearch" )
             .getTermsEnum( ["cities","towns"], {
                 "field" : "name",
                 "string" : "west",
@@ -406,7 +406,7 @@ The ["Term Vectors" Elasticsearch API](https://www.elastic.co/guide/en/elasticse
 To retrieve term vectors for a known document ID, pass the index name, id, and an array or list of fields to pull from:
 
 ```js
-var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
+var result = getInstance( "HyperClient@cbelasticsearch" ).getTermVectors(
     "books",
     "book_12345",
     [ "title" ]
@@ -416,7 +416,7 @@ var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
 You can fine-tune the request using the `options` argument:
 
 ```js
-var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
+var result = getInstance( "HyperClient@cbelasticsearch" ).getTermVectors(
     indexName = "books",
     id = "book_12345",
     options = {
@@ -433,7 +433,7 @@ See the [query parameters](https://www.elastic.co/guide/en/elasticsearch/referen
 If you wish to analyze a payload (not an existing document) you can pass a `"doc"` payload in the `options` argument:
 
 ```js
-var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
+var result = getInstance( "HyperClient@cbelasticsearch" ).getTermVectors(
     indexName = "books",
     fields = [ "title" ],
     options = {
@@ -449,7 +449,7 @@ var result = getInstance( "HyperClient@cbElasticsearch" ).getTermVectors(
 The SearchBuilder object also offers a `getTermVectors()` method for convenience:
 
 ```js
-var result = getInstance( "SearchBuilder@cbElasticsearch" )
+var result = getInstance( "SearchBuilder@cbelasticsearch" )
                 .new( "books" )
                 .getTermVectors(
                     myDocument._id,

--- a/docs/Tasks.md
+++ b/docs/Tasks.md
@@ -11,7 +11,7 @@ An example, using the reindex method and flushing the status output to the brows
 ```js
 var oldIndex = "books_v1";
 var newIndex = "books_v2";
-var reindexTask = getInstance( "Client@cbElasticsearch" )
+var reindexTask = getInstance( "Client@cbelasticsearch" )
                         .reindex(
                             source = oldIndex,
                             destination = newIndex,


### PR DESCRIPTION
Minor tweaks for the docs to ensure we use the lowercased module slug in all `getInstance()` calls, for consistency and to ensure wirebox continues working on case-sensitive systems.