### PR TITLE
Param reindex status in case of failure

### DIFF
--- a/models/io/HyperClient.cfc
+++ b/models/io/HyperClient.cfc
@@ -444,6 +444,7 @@ component accessors="true" threadSafe singleton {
 		var reindexResult = requestBuilder.send().json();
 
 		if ( arguments.waitForCompletion && arguments.throwOnError ) {
+			param reindexResult.status = "[NONE]";
 			if ( reindexResult.keyExists( "failures" ) && reindexResult.failures.len() ) {
 				throw(
 					type         = "cbElasticsearch.HyperClient.ReindexFailedException",


### PR DESCRIPTION
This prevents cbelasticsearch from bombing on reindex results that don't return a status for some reason.