### PR TITLE
Improve error handling for non-JSON responses to include status code in message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ----
 ## [Unreleased]
 
+### Added
+
+* Improved error handling to include the status code in the error message if a "reason" could not be extracted from the response: `Elasticsearch server responded with [504 Gateway Timeout]. The response received was not JSON.`.
+
 ## [3.3.0] - 04-18-2024
 
 ### Added

--- a/models/util/Util.cfc
+++ b/models/util/Util.cfc
@@ -108,27 +108,20 @@ component accessors="true" singleton {
 				 : ""
 			);
 		}
+		var message = "Your request was invalid.  The response returned was #toJSON( errorPayload )#";
+		var type = "cbElasticsearch.invalidRequest";
 		if ( len( errorReason ) && !isSimpleValue( errorPayload.error ) && errorPayload.error.keyExists( "type" ) ) {
-			throw(
-				type         = "cbElasticsearch.native.#errorPayload.error.type#",
-				message      = "An error was returned when communicating with the Elasticsearch server.  The error received was: #errorReason#",
-				errorCode    = errorPayload.status,
-				extendedInfo = isJSON( errorPayload ) ? errorPayload : toJSON( errorPayload )
-			)
+			type = "cbElasticsearch.native.#errorPayload.error.type#";
+			message = "An error was returned when communicating with the Elasticsearch server.  The error received was: #errorReason#";
 		} else if ( isSimpleValue( errorPayload ) && !isJSON( errorPayload ) ) {
-			throw(
-				type         = "cbElasticsearch.invalidRequest",
-				message      = "An error occurred while communicating with the Elasticsearch server. The response received was not JSON",
-				extendedInfo = errorPayload,
-				errorCode    = response.getStatusCode()
-			);
-		} else {
-			throw(
-				type         = "cbElasticsearch.invalidRequest",
-				message      = "Your request was invalid.  The response returned was #toJSON( errorPayload )#",
-				extendedInfo = isJSON( errorPayload ) ? errorPayload : toJSON( errorPayload )
-			);
+			message = "Elasticsearch server responded with [#response.getStatus()#]. The response received was not JSON.";
 		}
+		throw(
+			type         = type,
+			message      = message,
+			errorCode    = isStruct( errorPayload ) && errorPayload.keyExists( "status" ) ? errorPayload.status : response.getStatusCode(),
+			extendedInfo = isJSON( errorPayload ) ? errorPayload : toJSON( errorPayload )
+		);
 	}
 
 	void function preflightLogEntry( required struct logObj ){

--- a/test-harness/tests/specs/unit/UtilTest.cfc
+++ b/test-harness/tests/specs/unit/UtilTest.cfc
@@ -105,6 +105,25 @@ component extends="coldbox.system.testing.BaseTestCase" {
 				} ).toThrow( "cbElasticsearch.native.BadDocument" );
 			} );
 
+			it( "tests handleResponseError with a 5xx status code", function(){
+				var mockResponse = getMockBox().createMock( className = "Hyper.models.HyperResponse" );
+
+				var mockError = '<html>
+					<head><title>504 Gateway Time-out</title></head>
+					<body>
+					<center><h1>504 Gateway Time-out</h1></center>
+					<hr><center>nginx</center>
+					</body>
+					</html>';
+				mockResponse.$( "getData", mockError );
+				mockResponse.$( "getStatusCode", 504 );
+				mockResponse.$( "getStatusText", "Gateway Time-out" );
+
+				expect( function(){
+					variables.model.handleResponseError( mockResponse );
+				} ).toThrow( "cbElasticsearch.invalidRequest" );
+			} );
+
 			it( "can strip newlines and tabs from Painless scripts", function() {
 				var uglyScript = "ArrayList a = new ArrayList();";
 				var uglyScriptWithTabs = "ArrayList a = 		new ArrayList();";


### PR DESCRIPTION
Non-JSON responses (typically network errors, in my experience) will now include the status code by default:

`Elasticsearch server responded with [504 Gateway Timeout]. The response received was not JSON.`